### PR TITLE
removed dctype from thumbnail

### DIFF
--- a/apps/iiif/serializers/canvas.py
+++ b/apps/iiif/serializers/canvas.py
@@ -112,7 +112,6 @@ class Serializer(JSONSerializer):
                 ],
                 "thumbnail" : {
                     "@id" : obj.thumbnail,
-                    "@type": "dctypes:Image",
                     "height": 250,
                     "width": 200
                 },


### PR DESCRIPTION
This is to fix the many
`WARNING: Resource type 'dctypes:Image' should have 'format' set`
validation errors when we verify our manifests.
