### PR TITLE
Fixed ID of annotation lists to match urls.py

### DIFF
--- a/apps/iiif/serializers/user_annotation_list.py
+++ b/apps/iiif/serializers/user_annotation_list.py
@@ -36,7 +36,7 @@ class Serializer(JSONSerializer):
         if ((self.version == 'v2') or (self.version is None)):
             data = {
                 "@context": "http://iiif.io/api/presentation/2/context.json",
-                "@id": "%s/annotations/%s/%s/%s/list" % (settings.HOSTNAME, self.owners[0].username, obj.manifest.pid, obj.pid),
+                "@id": "%s/annotations/%s/%s/list/%s" % (settings.HOSTNAME, self.owners[0].username, obj.manifest.pid, obj.pid),
                 "@type": "sc:AnnotationList",
                 "resources": json.loads(serialize('annotation', obj.userannotation_set.filter(owner__in=[self.owners[0].id]), is_list=True))
             }


### PR DESCRIPTION
This fixes a bug in which users are unable to export their annotations in the Jekyll download.