### PR TITLE
Feature/export email

### DIFF
--- a/apps/iiif/manifests/export.py
+++ b/apps/iiif/manifests/export.py
@@ -1,4 +1,3 @@
-from django.core.mail import send_mail
 from django.core.serializers import serialize
 from .models import Manifest
 from apps.iiif.annotations.models import Annotation
@@ -566,13 +565,6 @@ class JekyllSiteExport(object):
             except GithubExportException as err:
                 notify_msg('Export failed: %s' % err, 'error')
 
-        send_mail(
-            'Subject here',
-            'Here is the message.',
-            'benwbrum@gmail.com',
-            ['benwbrum@gmail.com'],
-            fail_silently=False,
-        )
         return [repo_url, ghpages_url, pr_url]
 
 

--- a/apps/iiif/manifests/export.py
+++ b/apps/iiif/manifests/export.py
@@ -1,3 +1,4 @@
+from django.core.mail import send_mail
 from django.core.serializers import serialize
 from .models import Manifest
 from apps.iiif.annotations.models import Annotation
@@ -564,6 +565,14 @@ class JekyllSiteExport(object):
                 ghpages_url = 'https://%s.github.io/%s/' % (self.github_username, self.github_repo)
             except GithubExportException as err:
                 notify_msg('Export failed: %s' % err, 'error')
+
+        send_mail(
+            'Subject here',
+            'Here is the message.',
+            'benwbrum@gmail.com',
+            ['benwbrum@gmail.com'],
+            fail_silently=False,
+        )
         return [repo_url, ghpages_url, pr_url]
 
 

--- a/apps/templates/jekyll_export_email.html
+++ b/apps/templates/jekyll_export_email.html
@@ -1,0 +1,38 @@
+
+{% block content %}
+
+<h1 class='uk-text-truncate'>
+  {{volume.label}}    
+</h1>
+{% endblock content %}
+{% block viewer %}
+  <div class='uk-flex-center' uk-grid>
+    <div class='uk-width-3-4'>
+      <div class='uk-padding'>
+        <h3>Static Site Export</h3>
+
+
+        {% if pr_url %}
+          <div class="alert alert-success">GitHub jekyll site update succeeded.</div>
+
+          <p>A new <a class="pullrequest-url" href="{{ pr_url }}">pull request</a> has been created
+          on your <a class="repo-url" href="{{ repo_url }}">GitHub repository</a> with all the latest
+          changes.  You can review the changes and merge them into <a href="{{ ghpages_url }}">your
+          published edition</a>.</p>
+        {% else %}
+          <div class="alert alert-success">GitHub Jekyll site export succeeded.</div>
+          <p>Your website export has been generated and saved to a new
+          GitHub repository at <a class="repo-url" href="{{ repo_url }}">{{ repo_url }}</a>.<br/>
+          After a few minutes, your annotated web edition should be accessible via GitHub Pages
+          at <a class="ghpages-url" href="{{ ghpages_url }}">{{ ghpages_url }}</a>.</p>
+
+          <p>For more information on using and customizing your site,
+          see the
+          <a href="https://help.github.com/categories/github-pages-basics/">Github
+          Pages help documentation</a>.</p>
+        {% endif %}
+      </div>
+
+    </div>
+  </div>
+{% endblock viewer %}

--- a/apps/templates/jekyll_export_email.txt
+++ b/apps/templates/jekyll_export_email.txt
@@ -1,0 +1,29 @@
+{{volume.label}}    
+
+Static Site Export
+
+{% if pr_url %}
+GitHub jekyll site update succeeded.
+
+A new pull request has been created on your GitHub repository 
+with all the latest changes.  You can review the changes and 
+merge them into your published edition.
+
+Review your pull request: {{ pr_url }}
+Your repository: {{ repo_url }}
+Your published edition: {{ ghpages_url }}
+{% else %}
+GitHub Jekyll site export succeeded.
+
+Your website export has been generated and saved to a new GitHub repository.
+
+After a few minutes, your annotated web edition should be accessible via 
+GitHub Pages.
+
+Your repository: {{ repo_url }}
+Your published edition: {{ ghpages_url }}
+
+For more information on using and customizing your site, see the
+Github Pages help documentation at:
+https://help.github.com/categories/github-pages-basics/
+{% endif %}

--- a/config/settings/local.dst
+++ b/config/settings/local.dst
@@ -43,6 +43,22 @@ TEMPLATES[0]['OPTIONS']['debug'] = DEBUG  # noqa F405
 EMAIL_HOST = 'localhost'
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-port
 EMAIL_PORT = 1025
+# Actually send emails rather than printing to standard output
+# EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend" 
+# 
+# Email address to use as "From" for automated emails.
+READUX_EMAIL_SENDER='readux@ecds.emory.edu'
+
+# For developer testing with gmail, use the following: 
+# EMAIL_PORT=587 
+# EMAIL_HOST="smtp.gmail.com" 
+# EMAIL_USE_TLS=True 
+# EMAIL_HOST_USER="your Gmail username without @gmail.com" 
+# EMAIL_HOST_PASSWORD="your Gmail password"
+# In addition, you will need to edit your Gmail account to let less-secure apps connect at:
+# https://myaccount.google.com/lesssecureapps
+
+
 
 # django-debug-toolbar
 # ------------------------------------------------------------------------------
@@ -142,3 +158,4 @@ LOGGING = {
         },
  },
 }
+


### PR DESCRIPTION
This feature emails a user when their static site export to Github has finished.  

To test this functionality on a development machine, you will need to connect to an SMTP server.  `config/settings/local.dst` has an expanded email stanza containing instructions for testing with Gmail.