### PR TITLE
Feature/tag export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'iiif_to_jekyll', '0.3.0', git: 'https://github.com/ecds/iiif-to-jekyll.git'
+gem 'iiif_to_jekyll', '0.4.1', git: 'https://github.com/ecds/iiif-to-jekyll.git'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'iiif_to_jekyll', '0.4.1', git: 'https://github.com/ecds/iiif-to-jekyll.git'
+gem 'iiif_to_jekyll', '0.4.2', git: 'https://github.com/ecds/iiif-to-jekyll.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/ecds/iiif-to-jekyll.git
-  revision: 73048492086e96a12967fc8332408e264ac27b9f
+  revision: b0c00c8f272ebbbeec9b6606966cba6bb4747e54
   specs:
-    iiif_to_jekyll (0.4.1)
+    iiif_to_jekyll (0.4.2)
       iiif-presentation (~> 0.2.0)
       openssl
 
@@ -39,7 +39,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  iiif_to_jekyll (= 0.4.1)!
+  iiif_to_jekyll (= 0.4.2)!
 
 BUNDLED WITH
    1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,45 @@
 GIT
   remote: https://github.com/ecds/iiif-to-jekyll.git
-  revision: 5bab7e0ce4224af8b7ececf65bf5c78e51949aa5
+  revision: 73048492086e96a12967fc8332408e264ac27b9f
   specs:
-    iiif_to_jekyll (0.3.0)
+    iiif_to_jekyll (0.4.1)
       iiif-presentation (~> 0.2.0)
       openssl
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.0.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    concurrent-ruby (1.1.5)
-    faraday (0.16.2)
+      zeitwerk (~> 2.2)
+    concurrent-ruby (1.1.6)
+    faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
-    i18n (1.6.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     iiif-presentation (0.2.0)
       activesupport (>= 3.2.18)
       faraday (>= 0.9)
       json
-    json (2.2.0)
-    minitest (5.12.2)
+    ipaddr (1.2.2)
+    json (2.3.0)
+    minitest (5.14.0)
     multipart-post (2.1.1)
     openssl (2.1.2)
+      ipaddr
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  iiif_to_jekyll (= 0.3.0)!
+  iiif_to_jekyll (= 0.4.1)!
 
 BUNDLED WITH
-   2.1.0
+   1.17.3


### PR DESCRIPTION
This displays tags in the jekyll generated export of a readux edition. It requires an updated version of the iiif-to-jekyll gem, so please run the requirements and bundle install after it is deployed.