### PR TITLE
another typo in search results and added missing canvases for meta se…

### DIFF
--- a/apps/readux/views.py
+++ b/apps/readux/views.py
@@ -520,7 +520,7 @@ class VolumeSearch(ListView):
 
                     qs2 = qs.values(
                         'canvas__pid', 'pid',
-                        'canvas__manifest__image_server_server_base'
+                        'canvas__manifest__image_server__server_base'
                     ).order_by(
                         'pid'
                     ).distinct('pid')

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -67,7 +67,7 @@
 
     <div class="uk-width-1-4@m rx-volume-image">  {% for value in qs2 %}{% if value.pid == volume.pid %}
       <a class="nav-link" href="https://{{ request.META.HTTP_HOST }}{% url 'volumeall' volume.pid %}?q={{ request.GET.q }}&type={{ request.GET.type }}" target="">
-<img src="{{ value.canvas__manifest__image_server_server_base }}/{{ value.canvas__pid }}/pct:5,5,90,90/,250/0/default.jpg" alt="First page of {{volume.label}}" onerror="this.onerror=null;this.src='{% static '/images/image_not_found.jpg' %}';"/>
+<img src="{{ value.canvas__manifest__image_server__server_base }}/{{ value.canvas__pid }}/pct:5,5,90,90/,250/0/default.jpg" alt="First page of {{volume.label}}" onerror="this.onerror=null;this.src='{% static '/images/image_not_found.jpg' %}';"/>
       </a>{% endif %}{% endfor %}
     </div>
     <div class="uk-width-3-4@m">
@@ -105,11 +105,46 @@
 <hr/>
 <div class="uk-grid-match uk-child-width-expand@s uk-grid-large uk-margin-bottom" uk-grid>
   {% for volume in qs3 %}
+  {% if volume.canvas_set.first.pid is null %}
+      <div class="uk-width-1-2@m uk-grid-medium">
+        <div class=" uk-width-1-4@m">
+          <a class="nav-link" href="#">
+            <v-volume-image></v-volume-image>
+          </a>
+        </div>
+        <div class="uk-width-3-4@m" tabindex="0">
+          <a class="nav-link" href="#">
+            <h3 class="rx-card-title uk-margin-remove-bottom" title="{{ volume.label }}">{{ volume.label|truncatechars:100 }}</h3>
+          </a>
+          <ul class="uk-padding-remove rx-card-text">
+            <li>Author: {{volume.author|truncatechars:150}}</li>
+            <li>Published: {{volume.published_date}}</li>
+            <li>Publisher: {{volume.publisher}}</li>
+            <li>Publication City: {{volume.published_city}}</li>
+            <li>Added: {{volume.created_at}}</li>
+            <li>
+              {% for value in user_annotation_count %}
+              {% if volume.pid in value %}
+              {% if "0" not in value|safe|slice:"-3:-1" %}
+              <span class="count-icon">
+                <span class="uk-icon" uk-icon="icon: comments; ratio: 1.5"
+                  uk-tooltip="title: Number of your annotations; pos: bottom"></span>
+                <span class="count">{{ value|safe|slice:"-3:-1" }}</span>
+              </span>
+              {% endif %}
+              {% endif %}
+              {% endfor %}
+            </li>
+          </ul>
+        </div>
+      </div>
+
+    {% else %}
   <div class="uk-width-1-2@m uk-grid-medium">
 
     <div class="uk-width-1-4@m rx-volume-image">  {% for value in qs2 %}{% if value.pid == volume.pid %}
       <a class="nav-link" href="https://{{ request.META.HTTP_HOST }}{% url 'volumeall' volume.pid %}?q={{ request.GET.q }}&type={{ request.GET.type }}" target="">
-<img src="{{ value.canvas__manifest__image_server_server_base }}/{{ value.canvas__pid }}/pct:5,5,90,90/,250/0/default.jpg" alt="First page of {{volume.label}}" onerror="this.onerror=null;this.src='{% static '/images/image_not_found.jpg' %}';"/>
+<img src="{{ value.canvas__manifest__image_server__server_base }}/{{ value.canvas__pid }}/pct:5,5,90,90/,250/0/default.jpg" alt="First page of {{volume.label}}" onerror="this.onerror=null;this.src='{% static '/images/image_not_found.jpg' %}';"/>
       </a>{% endif %}{% endfor %}
     </div>
     <div class="uk-width-3-4@m">
@@ -135,6 +170,7 @@
       </ul>
     </div>
   </div>
+  {% endif %}
   {% endfor %}
   {% if not qs3 %}
   <div><span class="results" style="background:#fff1e4;font-size:2em;color:#707070;"> There were no results for <em>{{ request.GET.q }}</em> in Metadata: Title/Author/Summary.</span></div>
@@ -143,4 +179,3 @@
       {% endif %}
 
 {% endblock content %}
-


### PR DESCRIPTION
Added a couple of more fixes for search (typos and the correct 'missing canvases' error icon/link if you have a manifest without canvases).  It should be fully working with this change. This shouldn't touch anything else. 