### PR TITLE
Support external metadata file in batch ingest

### DIFF
--- a/apps/ingest/admin.py
+++ b/apps/ingest/admin.py
@@ -1,13 +1,13 @@
 """[summary]"""
-import os
-from apps.ingest.storages import IngestStorage
 import logging
+from mimetypes import guess_type
 from os import environ, path
 from django.contrib import admin
 from django.shortcuts import redirect
-import apps.ingest.tasks as tasks
+from apps.ingest import tasks
+from apps.ingest.storages import IngestStorage
 from .models import Bulk, Local, Remote
-from .services import create_manifest
+from .services import clean_metadata, create_manifest, get_associated_meta, get_metadata_from
 from .forms import BulkVolumeUploadForm
 
 LOGGER = logging.getLogger(__name__)
@@ -52,25 +52,44 @@ class RemoteAdmin(admin.ModelAdmin):
         return redirect('/admin/manifests/manifest/{m}/change/'.format(m=manifest_id))
 
 class BulkAdmin(admin.ModelAdmin):
+    """Django admin ingest.models.bulk resource."""
+
     form = BulkVolumeUploadForm
 
     def save_model(self, request, obj, form, change):
         form.storage = IngestStorage()
         obj.save()
-        files = request.FILES.getlist('volume_files')
-        for f in files:
-            path = form.storage.save(os.path.join('bulk', str(obj.id), f.name), f)
-            new_local = Local.objects.create(bulk=obj, bundle=path, image_server=obj.image_server)
-            if environ['DJANGO_ENV'] != 'test':
+        # Get files from multi upload form
+        files = request.FILES.getlist("volume_files")
+        # Find the metadata file and load it into list of dicts
+        all_metadata = get_metadata_from(files)
+        for file in files:
+            # Skip metadata file now
+            if 'metadata' in file.name.casefold() and 'zip' not in guess_type(file.name)[0]:
+                continue
+            # Associate metadata with zipfile
+            if all_metadata is not None:
+                file_meta = clean_metadata(get_associated_meta(all_metadata, file))
+            else:
+                file_meta = {}
+            # Save in storage
+            bundle_path = form.storage.save(
+                path.join("bulk", str(obj.id), file.name), file
+            )
+            # Create local
+            new_local = Local.objects.create(
+                bulk=obj, bundle=bundle_path, image_server=obj.image_server, metadata=file_meta
+            )
+            if environ["DJANGO_ENV"] != "test":
                 tasks.create_canvas_form_local_task.delay(new_local.id)
         obj.refresh_from_db()
         super().save_model(request, obj, form, change)
 
     def response_add(self, request, obj, post_url_continue=None):
         obj.delete()
-        return redirect('/admin/manifests/manifest/?o=-4')
+        return redirect("/admin/manifests/manifest/?o=-4")
 
-    class Meta: # pylint: disable=too-few-public-methods, missing-class-docstring
+    class Meta:  # pylint: disable=too-few-public-methods, missing-class-docstring
         model = Bulk
 
 admin.site.register(Local, LocalAdmin)

--- a/apps/ingest/fixtures/metadata.csv
+++ b/apps/ingest/fixtures/metadata.csv
@@ -1,0 +1,2 @@
+PID,Label,Summary,Author,Published city,Published date,Publisher
+no_meta_file,Test Bundle,Test file,Test author,Test City,2021,Pubilsher test


### PR DESCRIPTION
### What this PR does

- Adds support for an external metadata file, by matching PID column to zip file names
  - Uses `get_metadata_from(files)` service function to find a metadata file among list of uploaded files (i.e. no zips have yet been extracted)
  - If it finds one, uses `get_associated_meta` to associate each uploaded zip with a row (`dict`) in the metadata by value in the PID column (calling `clean_metadata` before association)
  - If there's no external metadata, or no row in the metadata where PID matches a zip's file name, zip's metadata will be handled by local ingest
- Adds test for this functionality to `test_admin.py`