### PR TITLE
Expect 'filename' column in batch ingest

### DIFF
--- a/apps/ingest/fixtures/metadata.csv
+++ b/apps/ingest/fixtures/metadata.csv
@@ -1,2 +1,2 @@
-PID,Label,Summary,Author,Published city,Published date,Publisher
+Filename,Label,Summary,Author,Published city,Published date,Publisher
 no_meta_file,Test Bundle,Test file,Test author,Test City,2021,Pubilsher test

--- a/apps/ingest/services.py
+++ b/apps/ingest/services.py
@@ -48,7 +48,7 @@ def create_manifest(ingest):
             setattr(manifest, key, value)
     else:
         # PID generation
-        manifest = Manifest(pid=str(uuid4()))
+        manifest = Manifest(pid=generate_pid())
 
     manifest.image_server = ingest.image_server
     manifest.save()
@@ -176,5 +176,13 @@ def get_associated_meta(all_metadata, file):
         if metadata_found_filename and metadata_found_filename in (extless_filename, file.name):
             file_meta = meta_dict
             # PID generation
-            file_meta['pid'] = str(uuid4())
+            file_meta['pid'] = generate_pid()
     return file_meta
+
+def generate_pid():
+    """
+    Generate a PID for a volume.
+    :return: Returns a newly generated PID
+    :rtype: str
+    """
+    return str(uuid4())

--- a/apps/ingest/services.py
+++ b/apps/ingest/services.py
@@ -173,7 +173,7 @@ def get_associated_meta(all_metadata, file):
             if key.casefold() == 'filename':
                 metadata_found_filename = val
         # Match filename column, case-sensitive, against filename
-        if metadata_found_filename and metadata_found_filename == extless_filename:
+        if metadata_found_filename and metadata_found_filename in (extless_filename, file.name):
             file_meta = meta_dict
             # PID generation
             file_meta['pid'] = str(uuid4())

--- a/apps/ingest/services.py
+++ b/apps/ingest/services.py
@@ -47,6 +47,7 @@ def create_manifest(ingest):
         for (key, value) in metadata.items():
             setattr(manifest, key, value)
     else:
+        # PID generation
         manifest = Manifest(pid=str(uuid4()))
 
     manifest.image_server = ingest.image_server
@@ -161,20 +162,19 @@ def get_metadata_from(files):
 def get_associated_meta(all_metadata, file):
     """
     Associate metadata with filename.
-    :return: If a matching PID is found, returns the row as dict. Otherwise, returns {}.
+    :return: If a matching filename is found, returns the row as dict,
+        with generated pid. Otherwise, returns {}.
     :rtype: dict
     """
     file_meta = {}
     extless_filename = file.name[0:file.name.rindex('.')]
     for meta_dict in all_metadata:
         for key, val in meta_dict.items():
-            if key.casefold() == 'pid':
-                pid = val
-            else:
-                continue
-        # Match pid, case-sensitive, against filename
-        if pid and pid == extless_filename:
+            if key.casefold() == 'filename':
+                metadata_found_filename = val
+        # Match filename column, case-sensitive, against filename
+        if metadata_found_filename and metadata_found_filename == extless_filename:
             file_meta = meta_dict
-        else:
-            continue
+            # PID generation
+            file_meta['pid'] = str(uuid4())
     return file_meta

--- a/apps/ingest/tests/test_admin.py
+++ b/apps/ingest/tests/test_admin.py
@@ -188,7 +188,7 @@ class IngestAdminTest(TestCase):
         assert local.metadata is not None
         assert isinstance(local.metadata, dict)
         assert len(local.metadata) != 0
-        assert local.metadata['pid'] == 'no_meta_file'
+        assert local.metadata['label'] == 'Test Bundle'
 
     # def test_local_admin_save_update_manifest(self):
     #     """It should add a manifest to the Local object"""


### PR DESCRIPTION
### What this PR does

During batch ingest with an external metadata file:
- Expects `filename` column (case-insensitive) in metadata to match a filename (case-sensitive) of a zip file
- Generates PID using `uuid4` instead of using `pid` column

### Additional notes

- This code sticks with UUIDs for now; this could be easily changed by modifying the `generate_pid()` function.
- If a user passes in a single volume zip with a metadata file inside the zip, and it has a `pid` column, it will still be used as before. This PR only affects how an external metadata file associates zip filenames