### PR TITLE
Fix manifest creation when no PID specified

### DIFF
--- a/apps/ingest/services.py
+++ b/apps/ingest/services.py
@@ -45,9 +45,9 @@ def create_manifest(ingest):
         metadata = None
     if metadata:
         if 'pid' in metadata:
-            manifest, created = Manifest.objects.get_or_create(pid=metadata['pid'].replace('_', '-'))
+            manifest = Manifest.objects.get_or_create(pid=metadata['pid'].replace('_', '-'))
         else:
-            manifest, created = Manifest.objects.get_or_create()
+            manifest = Manifest.objects.create()
         for (key, value) in metadata.items():
             setattr(manifest, key, value)
     else:

--- a/apps/ingest/services.py
+++ b/apps/ingest/services.py
@@ -45,7 +45,7 @@ def create_manifest(ingest):
         metadata = None
     if metadata:
         if 'pid' in metadata:
-            manifest = Manifest.objects.get_or_create(pid=metadata['pid'].replace('_', '-'))
+            manifest = Manifest.objects.get_or_create(pid=metadata['pid'].replace('_', '-'))[0]
         else:
             manifest = Manifest.objects.create()
         for (key, value) in metadata.items():


### PR DESCRIPTION
This PR fixes `create_manifest` for ingests that include metadata without a `pid` column.