### PR TITLE
Add manifests to collections action

### DIFF
--- a/apps/iiif/manifests/admin.py
+++ b/apps/iiif/manifests/admin.py
@@ -6,7 +6,6 @@ from import_export import resources, fields
 from import_export.admin import ImportExportModelAdmin
 from import_export.widgets import ManyToManyWidget, ForeignKeyWidget
 from django_summernote.admin import SummernoteModelAdmin
-
 from .models import Manifest, Note, ImageServer
 from .forms import ManifestAdminForm
 from .views import AddToCollectionsView

--- a/apps/iiif/manifests/forms.py
+++ b/apps/iiif/manifests/forms.py
@@ -1,6 +1,9 @@
 """Django Forms for export."""
 import logging
 from django import forms
+from django.contrib.admin import site as admin_site, widgets
+
+from apps.iiif.kollections.models import Collection
 from .models import Manifest
 from ..canvases.models import Canvas
 
@@ -84,3 +87,17 @@ class ManifestAdminForm(forms.ModelForm):
             self.fields['start_canvas'].queryset = kwargs['instance'].canvas_set.all()
         else:
             self.fields['start_canvas'].queryset = Canvas.objects.none()
+
+class ManifestsCollectionsForm(forms.ModelForm):
+    """Form to add manifests to collections."""
+    class Meta:
+        model = Manifest
+        fields=('collections',)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['collections'].widget = widgets.RelatedFieldWidgetWrapper(
+               self.fields['collections'].widget,
+               self.instance._meta.get_field('collections').remote_field,           
+               admin_site,
+        )

--- a/apps/iiif/manifests/templates/add_manifests_to_collections.html
+++ b/apps/iiif/manifests/templates/add_manifests_to_collections.html
@@ -1,0 +1,38 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+{% load static %}
+
+{% block extrastyle %}
+  <link rel="stylesheet" type="text/css" href="/static/admin/css/forms.css">
+{% endblock %}
+
+{% block content %}
+  <form method="post">{% csrf_token %}
+    <fieldset class="module aligned ">
+      <div class="form-row">
+        <div>
+          <label class="required">{% trans 'Manifests selected' %}:</label>
+          <div>
+            <ul>
+              {% for manifest in manifests %}
+              <li>
+                {% trans 'unlabeled' as unlabeled %}
+                <strong>{{ manifest.label|default:unlabeled }}</strong>
+                ({{ manifest.pk }})
+              </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="form-row">
+        {{ form }}
+      </div>
+    </fieldset>
+    {% block submit_buttons_bottom %}
+      <div class="submit-row">
+        <input type="submit" value="{% trans 'Save' %}" class="default" name="_save">
+      </div>
+    {% endblock %}
+  </form>
+{% endblock %}

--- a/apps/iiif/manifests/views.py
+++ b/apps/iiif/manifests/views.py
@@ -223,9 +223,11 @@ class AddToCollectionsView(FormView):
         return super().form_valid(form)
 
     def add_manifests_to_collections(self, form):
+        """Adds selected manifests to selected collections from form"""
         context = self.get_context_data()
         manifests = context['manifests']
-        collections = form.cleaned_data['collections']
+        if form.is_valid():
+            collections = form.cleaned_data['collections']
         for manifest in manifests:
             manifest.collections.add(*collections)
             manifest.save()

--- a/apps/iiif/manifests/views.py
+++ b/apps/iiif/manifests/views.py
@@ -2,18 +2,21 @@
 import json
 import logging
 from datetime import datetime
+from django.contrib import messages
 from django.http import JsonResponse
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.template.response import TemplateResponse
 from django.views import View
 from django.views.generic.base import TemplateView
+from django.views.generic.edit import FormView
 from django.core.serializers import serialize
 from django.contrib.sitemaps import Sitemap
 from django.urls import reverse
 from ..canvases.models import Canvas
 from .models import Manifest
 from .export import IiifManifestExport
-from .forms import JekyllExportForm
+from .forms import JekyllExportForm, ManifestsCollectionsForm
 from .tasks import github_export_task
 from .tasks import download_export_task
 
@@ -198,3 +201,37 @@ class PlainExport(View):
         for canvas in self.get_queryset() :
             annotations.append(canvas.result)
         return HttpResponse(' '.join(annotations))
+
+class AddToCollectionsView(FormView):
+    """Intermediate page to choose collections to which you are adding manifests"""
+
+    template_name = 'add_manifests_to_collections.html'
+    form_class = ManifestsCollectionsForm
+
+    def get_context_data(self, **kwargs):
+        ids = self.request.GET.get('ids', '').split(',')
+        manifests = Manifest.objects.filter(pk__in=ids)
+        model_admin = self.kwargs['model_admin']
+        context = super().get_context_data(**kwargs)
+        context['model_admin'] = model_admin.admin_site.each_context(self.request)
+        context['manifests'] = manifests
+        context['title'] = 'Add selected manifests to collection(s)'
+        return context
+
+    def form_valid(self, form):
+        self.add_manifests_to_collections(form)
+        return super().form_valid(form)
+
+    def add_manifests_to_collections(self, form):
+        context = self.get_context_data()
+        manifests = context['manifests']
+        collections = form.cleaned_data['collections']
+        for manifest in manifests:
+            manifest.collections.add(*collections)
+            manifest.save()
+
+    def get_success_url(self):
+        messages.add_message(
+            self.request, messages.SUCCESS, 'Successfully added manifests to collections'
+        )
+        return reverse('admin:manifests_manifest_changelist')


### PR DESCRIPTION
### What this PR does
- Adds "Add manifests to collection(s)" action to Manifests admin changelist
  - Uses a custom action, view, form, and template to accomplish this
- Adds some basic tests for the above

### Additional notes
- I began writing tests in `test_views` but ran out of time to make them more thorough, and the form and admin methods also ought to be tested