### PR TITLE
Faceted / filtered search and sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Administrators can organize digitized books into collections, facilitating user 
 
 1. Python 3
 2. PostgreSQL
+3. Elasticsearch (>7.0, <7.14.0)
 
 ### Set up development environment
 
@@ -48,7 +49,7 @@ pip install -r requirements/local.txt
 bundle install
 ~~~
 
-1. Copy and set up your local settings.
+5. Copy and set up your local settings.
 
 ~~~bash
 cp config/settings/local.dst config/settings/local.py
@@ -58,6 +59,7 @@ cp config/settings/local.dst config/settings/local.py
 
 ~~~bash
 export DATABASE_URL=postgres://<database user>:<database password>@127.0.0.1:5432/<database name>
+export ELASTICSEARCH_URL=http://<elastic user>:<elastic password>@127.0.0.1:9200
 ~~~
 
 7. Run the migrations and load the example data.

--- a/apps/iiif/manifests/documents.py
+++ b/apps/iiif/manifests/documents.py
@@ -17,7 +17,7 @@ class ManifestDocument(Document):
     """Elasticsearch Document class for IIIF Manifest"""
 
     # fields to map explicitly in Elasticsearch
-    authors = fields.TextField(multi=True)
+    authors = fields.KeywordField(multi=True)
     collections = fields.NestedField(properties={
         "summary": fields.TextField(analyzer=html_strip),
         "attribution": fields.TextField(),
@@ -26,7 +26,7 @@ class ManifestDocument(Document):
     })
     # TODO: date = DateRange()
     has_pdf = fields.BooleanField()
-    languages = fields.TextField(multi=True)
+    languages = fields.KeywordField(multi=True)
     summary = fields.TextField(analyzer=html_strip)
 
     class Index:

--- a/apps/iiif/manifests/documents.py
+++ b/apps/iiif/manifests/documents.py
@@ -67,7 +67,7 @@ class ManifestDocument(Document):
         if instance.label:
             # use unidecode to unaccent characters
             return unidecode(instance.label[0:64], "utf-8")
-        return "No title"
+        return "[No label]"
 
     def prepare_languages(self, instance):
         """convert languages into list of strings"""

--- a/apps/iiif/manifests/documents.py
+++ b/apps/iiif/manifests/documents.py
@@ -4,6 +4,7 @@ from django_elasticsearch_dsl import Document, fields
 from django_elasticsearch_dsl.registries import registry
 from elasticsearch_dsl import analyzer
 from .models import Manifest
+from unidecode import unidecode
 
 html_strip = analyzer(
     "html_strip",
@@ -26,6 +27,7 @@ class ManifestDocument(Document):
     })
     # TODO: date = DateRange()
     has_pdf = fields.BooleanField()
+    label_alphabetical = fields.KeywordField()
     languages = fields.KeywordField(multi=True)
     summary = fields.TextField(analyzer=html_strip)
 
@@ -60,6 +62,13 @@ class ManifestDocument(Document):
         """convert pdf field into boolean"""
         return bool(instance.pdf)
     
+    def prepare_label_alphabetical(self, instance):
+        """get the first 64 chars of a label, just for sorting purposes"""
+        if instance.label:
+            # use unidecode to unaccent characters
+            return unidecode(instance.label[0:64], "utf-8")
+        return "No title"
+
     def prepare_languages(self, instance):
         """convert languages into list of strings"""
         return [lang.name for lang in instance.languages.all()]

--- a/apps/readux/forms.py
+++ b/apps/readux/forms.py
@@ -10,8 +10,8 @@ class FacetedMultipleChoiceField(forms.MultipleChoiceField):
         """Populate the field choices from the buckets returned by Elasticsearch."""
         self.choices = (
             (
-                bucket.key,
-                f'{truncatechars(bucket.key, 64)} ({bucket.doc_count})',
+                bucket["key"],
+                f'{truncatechars(bucket["key"], 64)} ({bucket["doc_count"]})',
             )
             for bucket in sorted(buckets, key=lambda b: b["key"]) # sort choices by name
         )

--- a/apps/readux/forms.py
+++ b/apps/readux/forms.py
@@ -5,6 +5,7 @@ from django.template.defaultfilters import truncatechars
 
 class FacetedMultipleChoiceField(forms.MultipleChoiceField):
     """MultipleChoiceField populated by Elasticsearch facets"""
+    # adapted from Princeton-CDH/geniza project https://github.com/Princeton-CDH/geniza/
 
     def populate_from_buckets(self, buckets):
         """Populate the field choices from the buckets returned by Elasticsearch."""
@@ -58,6 +59,8 @@ class ManifestSearchForm(forms.Form):
         label="Sort",
         required=False,
         choices=(
+            ("-created_at", "Date added (newest first)"),
+            ("created_at", "Date added (oldest first)"),
             ("label_alphabetical", "Label (A-Z)"),
             ("-label_alphabetical", "Label (Z-A)"),
             ("_score", "Relevance"),

--- a/apps/readux/forms.py
+++ b/apps/readux/forms.py
@@ -44,7 +44,6 @@ class ManifestSearchForm(forms.Form):
             },
         ),
     )
-
     author = FacetedMultipleChoiceField(
         label="Author",
         required=False,
@@ -52,6 +51,20 @@ class ManifestSearchForm(forms.Form):
             attrs={
                 "aria-label": "Filter volumes by author",
                 "class": "uk-input",
+            },
+        ),
+    )
+    sort = forms.ChoiceField(
+        label="Sort",
+        required=False,
+        choices=(
+            ("label_alphabetical", "Label (A-Z)"),
+            ("-label_alphabetical", "Label (Z-A)"),
+            ("_score", "Relevance"),
+        ),
+        widget=forms.Select(
+            attrs={
+                "class":"uk-select",
             },
         ),
     )

--- a/apps/readux/forms.py
+++ b/apps/readux/forms.py
@@ -1,6 +1,24 @@
 """Forms for Readux search"""
 
 from django import forms
+from django.template.defaultfilters import truncatechars
+
+class FacetedMultipleChoiceField(forms.MultipleChoiceField):
+    """MultipleChoiceField populated by Elasticsearch facets"""
+
+    def populate_from_buckets(self, buckets):
+        """Populate the field choices from the buckets returned by Elasticsearch."""
+        self.choices = (
+            (
+                bucket.key,
+                f'{truncatechars(bucket.key, 64)} ({bucket.doc_count})',
+            )
+            for bucket in sorted(buckets, key=lambda b: b["key"]) # sort choices by name
+        )
+
+    def valid_value(self, value):
+        """failsafe for chosen but unloaded facet"""
+        return True
 
 class ManifestSearchForm(forms.Form):
     """Django form for searching Manifests via Elasticsearch"""
@@ -16,3 +34,31 @@ class ManifestSearchForm(forms.Form):
             },
         ),
     )
+    language = FacetedMultipleChoiceField(
+        label="Language",
+        required=False,
+        widget=forms.SelectMultiple(
+            attrs={
+                "aria-label": "Filter volumes by language",
+                "class": "uk-input",
+            },
+        ),
+    )
+
+    author = FacetedMultipleChoiceField(
+        label="Author",
+        required=False,
+        widget=forms.SelectMultiple(
+            attrs={
+                "aria-label": "Filter volumes by author",
+                "class": "uk-input",
+            },
+        ),
+    )
+
+    def set_facets(self, facets):
+        """Use facets from Elasticsearch to populate form fields"""
+        for name, buckets in facets.items():
+            if name in self.fields:
+                # Assumes that name passed in the view's facets list matches form field name
+                self.fields[name].populate_from_buckets(buckets)

--- a/apps/readux/tests/test_forms.py
+++ b/apps/readux/tests/test_forms.py
@@ -25,7 +25,7 @@ class TestFacetedMultipleChoiceField:
         # should truncate keys >= 64 characters for label
         random_100_chars = ''.join(random.choices(string.ascii_letters, k=100))
         fake_buckets = [{"key": random_100_chars, "doc_count": 120}]
-        facetfield.populate_from_buckets(buckets=fake_buckets)  
+        facetfield.populate_from_buckets(buckets=fake_buckets)
         assert (random_100_chars, f"{random_100_chars} (120)") not in facetfield.choices
         truncated = f"{random_100_chars[0:63]}…"
         assert (random_100_chars, f"{truncated} (120)") in facetfield.choices

--- a/apps/readux/tests/test_forms.py
+++ b/apps/readux/tests/test_forms.py
@@ -1,0 +1,50 @@
+"""Tests for custom form components for search"""
+
+import random
+import string
+from unittest.mock import Mock
+from apps.readux.forms import FacetedMultipleChoiceField, ManifestSearchForm
+
+
+class TestFacetedMultipleChoiceField:
+    """Tests for multiple choice field for Elasticsearch facets"""
+
+    def test_valid_value(self):
+        """Should always return True"""
+        facetfield = FacetedMultipleChoiceField()
+        assert facetfield.valid_value("junk_string")
+
+    def test_populate_from_buckets(self):
+        """Should return choices based on passed buckets"""
+        facetfield = FacetedMultipleChoiceField()
+        fake_buckets = [{"key": "fake1", "doc_count": 0}, {"key": "fake2", "doc_count": 12}]
+        facetfield.populate_from_buckets(buckets=fake_buckets)
+        assert ("fake1", "fake1 (0)") in facetfield.choices
+        assert ("fake2", "fake2 (12)") in facetfield.choices
+
+        # should truncate keys >= 64 characters for label
+        random_100_chars = ''.join(random.choices(string.ascii_letters, k=100))
+        fake_buckets = [{"key": random_100_chars, "doc_count": 120}]
+        facetfield.populate_from_buckets(buckets=fake_buckets)  
+        assert (random_100_chars, f"{random_100_chars} (120)") not in facetfield.choices
+        truncated = f"{random_100_chars[0:63]}…"
+        assert (random_100_chars, f"{truncated} (120)") in facetfield.choices
+
+
+class TestManifestSearchForm:
+    """Tests for search form custom methods"""
+
+    def test_set_facets(self):
+        """Should call populate method on form fields based on facets retrieved from view"""
+        form = ManifestSearchForm()
+        example_field = Mock()
+        example_field.populate_from_buckets = Mock()
+        fake_buckets = [{"key": "fake1", "doc_count": 0}, {"key": "fake2", "doc_count": 12}]
+        form.fields = {
+            "example_field": example_field,
+        }
+        facets = {
+            "example_field": fake_buckets
+        }
+        form.set_facets(facets=facets)
+        example_field.populate_from_buckets.assert_called_with(fake_buckets)

--- a/apps/readux/views.py
+++ b/apps/readux/views.py
@@ -6,8 +6,9 @@ from django.views.generic import ListView
 from django.views.generic.base import TemplateView, View
 from django.views.generic.edit import FormMixin
 from django.contrib.sitemaps import Sitemap
-from django.db.models import Max, Q, Count
+from django.db.models import Max, Count
 from django.urls import reverse
+from elasticsearch_dsl import TermsFacet
 from elasticsearch_dsl.query import MultiMatch
 from apps.iiif.manifests.documents import ManifestDocument
 from apps.readux.forms import ManifestSearchForm
@@ -323,7 +324,17 @@ class VolumeSearchView(ListView, FormMixin):
     context_object_name = "volumes"
     paginate_by = 25
     # default fields to search when using query box; ^ with number indicates a boosted field
-    query_search_fields = ["pid", "label^3", "summary", "authors"]
+    query_search_fields = ["pid", "label^5", "summary^2", "authors"]
+
+    # Facet fields: tuples with (name, facet) where "name" matches the form field name,
+    # and "facet" is an Elasticsearch facet (with field argument matching the ManifestDocument
+    # field name for the desired field, and size argument accommodating all possible values)
+    facets = [
+        # NOTE: This size is set to accommodate all languages, of which there are 830 at present
+        ("language", TermsFacet(field="languages", size=1000, min_doc_count=0)),
+        # TODO: Determine a good size for authors or consider alternate approach (i.e. not faceted)
+        ("author", TermsFacet(field="authors", size=2000, min_doc_count=0)),
+    ]
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -331,6 +342,21 @@ class VolumeSearchView(ListView, FormMixin):
         form_data = self.request.GET.copy()
         kwargs["data"] = form_data
         return kwargs
+
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        volumes_response = self.get_queryset().execute()
+        # populate a dict with "buckets" of extant categories for each facet
+        facets = {}
+        for (facet, _) in self.facets:
+            if hasattr(volumes_response.aggregations, facet):
+                facets.update({
+                    # get buckets array from each facet in the aggregations dict
+                    facet: getattr(getattr(volumes_response.aggregations, facet), "buckets"),
+                })
+        context_data["form"].set_facets(facets)
+
+        return context_data
 
     def get_queryset(self):
         form = self.get_form()
@@ -346,164 +372,26 @@ class VolumeSearchView(ListView, FormMixin):
             multimatch_query = MultiMatch(query=search_query, fields=self.query_search_fields)
             volumes = volumes.query(multimatch_query)
 
+        # filter on authors
+        author_filter = form_data.get("author", "")
+        if author_filter:
+            volumes = volumes.filter("terms", authors=author_filter)
+
+        # filter on languages
+        language_filter = form_data.get("language", "")
+        if language_filter:
+            volumes = volumes.filter("terms", languages=language_filter)
+
+        # create aggregation buckets for facet fields
+        for (facet_name, facet) in self.facets:
+            volumes.aggs.bucket(facet_name, facet.get_aggregation())
+
         # sort by selected sort option
         volumes = volumes.sort("_score") # TODO: Implement other sorting options
 
+
         # return elasticsearch_dsl Search instance
         return volumes
-
-
-# TODO: Replace with Elasticsearch
-# class VolumeSearch(ListView):
-#     '''Search across all volumes.'''
-#     template_name = 'search_results.html'
-
-#     def get_queryset(self):
-#         return Manifest.objects.all()
-
-#     def get_context_data(self, **kwargs):
-#         context = super().get_context_data(**kwargs)
-#         collection = self.request.GET.get('collection', None)
-#         # pylint: disable = invalid-name
-#         COLSET = Collection.objects.values_list('pid', flat=True)
-#         COL_OPTIONS = list(COLSET)
-#         COL_LIST = Collection.objects.values('pid', 'label').order_by('label').distinct('label')
-#         # pylint: enable = invalid-name
-#         collection_url_params = self.request.GET.copy()
-
-#         qs = self.get_queryset()
-#         try:
-#             search_string = self.request.GET['q']
-#             search_type = self.request.GET['type']
-#             search_strings = self.request.GET['q'].split()
-#             if search_strings:
-#                 if search_type == 'partial':
-#                     qq = Q()
-#                     qqq = Q()
-#                     query = SearchQuery('')
-#                     for search_string in search_strings:
-#                         query = query | SearchQuery(search_string)
-#                         qq |= Q(canvas__annotation__content__icontains=search_string)
-#                         qqq |= Q(label__icontains=search_string) |Q(author__icontains=search_string) | Q(summary__icontains=search_string) # pylint: disable = line-too-long
-#                     qs1 = qs.filter(qq)
-#                     qs1 = qs1.values(
-#                         'pid', 'label', 'author',
-#                         'published_date', 'created_at'
-#                     ).annotate(
-#                         pidcount=Count('pid')
-#                     ).order_by('-pidcount')
-
-#                     vector2 = SearchVector(
-#                         'label', weight='A'
-#                     ) + SearchVector(
-#                         'author', weight='B'
-#                     ) + SearchVector(
-#                         'summary', weight='C'
-#                     )
-
-#                     qs3 = qs.filter(qqq)
-#                     qs2 = qs.values(
-#                         'label', 'author', 'published_date', 'created_at', 'canvas__pid', 'pid',
-#                         'canvas__manifest__image_server__server_base'
-#                     ).order_by(
-#                         'pid'
-#                     ).distinct(
-#                         'pid'
-#                     )
-
-#                     if collection not in COL_OPTIONS:
-#                         collection = None
-
-#                     if collection is not None:
-#                         qs1 = qs1.filter(collections__pid = collection)
-#                         qs3 = qs3.filter(collections__pid = collection)
-
-#                     if 'collection' in collection_url_params:
-#                         del collection_url_params['collection']
-#                 elif search_type == 'exact':
-#                     qq = Q()
-#                     query = SearchQuery('')
-#                     for search_string in search_strings:
-#                         query = query | SearchQuery(search_string)
-#                         qq |= Q(canvas__annotation__content__exact=search_string)
-#                     vector = SearchVector('canvas__annotation__content')
-#                     qs1 = qs.annotate(search=vector).filter(search=query)
-#                     qs1 = qs1.annotate(
-#                         rank=SearchRank(vector, query)
-#                     ).values(
-#                         'pid', 'label', 'author',
-#                         'published_date', 'created_at'
-#                     ).annotate(
-#                         pidcount = Count('pid')
-#                     ).order_by('-pidcount')
-
-#                     vector2 = SearchVector(
-#                         'label', weight='A'
-#                     ) + SearchVector(
-#                         'author', weight='B'
-#                     ) + SearchVector(
-#                         'summary', weight='C'
-#                     )
-
-#                     qs3 = qs.annotate(search=vector2).filter(search=query)
-#                     qs3 = qs3.annotate(
-#                         rank=SearchRank(vector2, query)
-#                     ).values(
-#                         'pid', 'label', 'author',
-#                         'published_date', 'created_at'
-#                     ).order_by('-rank')
-
-#                     qs2 = qs.values(
-#                         'canvas__pid', 'pid',
-#                         'canvas__manifest__image_server__server_base'
-#                     ).order_by(
-#                         'pid'
-#                     ).distinct('pid')
-
-#                     if collection not in COL_OPTIONS:
-#                         collection = None
-
-#                     if collection is not None:
-#                         qs1 = qs1.filter(collections__pid = collection)
-#                         qs3 = qs3.filter(collections__pid = collection)
-
-#                     if 'collection' in collection_url_params:
-#                         del collection_url_params['collection']
-#             else:
-#                 search_string = ''
-#                 search_strings = ''
-#                 qs1 = ''
-#                 qs2 = ''
-#                 qs3 = ''
-#             context['qs1'] = qs1
-#             context['qs2'] = qs2
-#             context['qs3'] = qs3
-#         except MultiValueDictKeyError:
-#             q = ''
-#             search_string = ''
-#             search_strings = ''
-
-#         context['volumes'] = qs.all
-#         annocount_list = []
-#         canvaslist = []
-#         for volume in qs:
-#             user_annotation_count = UserAnnotation.objects.filter(
-#                 owner_id=self.request.user.id
-#             ).filter(
-#                 canvas__manifest__id=volume.id
-#             ).count()
-#             annocount_list.append({volume.pid: user_annotation_count})
-#             context['user_annotation_count'] = annocount_list
-#             canvasquery = Canvas.objects.filter(is_starting_page=1).filter(manifest__id=volume.id)
-#             canvasquery2 = list(canvasquery)
-#             canvaslist.append({volume.pid: canvasquery2})
-#             context['firstthumbnail'] = canvaslist
-#         context.update({
-#             'collection_url_params': urlencode(collection_url_params),
-#             'collection': collection, 'COL_OPTIONS': COL_OPTIONS,
-#             'COL_LIST': COL_LIST, 'search_string': search_string, 'search_strings': search_strings
-#         })
-#         return context
 
 class ManifestsSitemap(Sitemap):
     """Django Sitemap for Manafests"""

--- a/apps/readux/views.py
+++ b/apps/readux/views.py
@@ -326,7 +326,7 @@ class VolumeSearchView(ListView, FormMixin):
     # default fields to search when using query box; ^ with number indicates a boosted field
     query_search_fields = ["pid", "label^5", "summary^2", "authors"]
 
-    # Facet fields: tuples with (name, facet) where "name" matches the form field name,
+    # Facet fields: tuples of (name, facet) where "name" matches the form field name,
     # and "facet" is an Elasticsearch facet (with field argument matching the ManifestDocument
     # field name for the desired field, and size argument accommodating all possible values)
     facets = [
@@ -361,14 +361,13 @@ class VolumeSearchView(ListView, FormMixin):
 
     def get_queryset(self):
         form = self.get_form()
-
         volumes = ManifestDocument.search()
 
         if not form.is_valid():
             # empty result on invalid form
             return volumes.filter("match_none")
-
         form_data = form.cleaned_data
+
         # default to empty string if no query in form data
         search_query = form_data.get("q", "")
         if search_query:

--- a/apps/static/css/project.css
+++ b/apps/static/css/project.css
@@ -1649,8 +1649,21 @@ a.nav-link {
 }
 /*# sourceMappingURL=project.css.map */
 
-input[type="search"][name="q"] {
+form#search-form input[type="search"][name="q"] {
   width: 100%;
+}
+form#search-form fieldset.two-column {
+  flex-wrap: wrap;
+}
+form#search-form fieldset.two-column div:first-child {
+  padding-right: 1rem;
+}
+
+form#search-form fieldset.two-column select[multiple] {
+  height: 150px;
+  width: 100%;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 ol#search-results {

--- a/apps/static/js/search.js
+++ b/apps/static/js/search.js
@@ -1,0 +1,54 @@
+// Scripts to improve search functionality
+// Adapted from Princeton-CDH/geniza project https://github.com/Princeton-CDH/geniza/
+
+let textInput;
+let sortElement;
+let relevanceSortOption;
+let defaultSortOption;
+
+$(document).ready(function() {
+    sortElement = document.querySelector("select#id_sort");
+    relevanceSortOption = sortElement.querySelector("option[value='_score']");
+    defaultSortOption = sortElement.querySelector("option[value='label_alphabetical']");
+    textInput = document.querySelector("input[type='search']");
+    // Attach event listeners to text input to update sort
+    textInput.addEventListener("input", autoUpdateSort);
+    if (textInput.value.trim() == "") {
+        disableRelevanceSort();
+    }
+});
+
+function autoUpdateSort() {
+    // when query is empty, disable sort by relevance
+    if (textInput.value.trim() == "") {
+        disableRelevanceSort();
+    // when query is entered, sort by relevance
+    } else {
+        sortByRelevance();
+    }
+}
+function sortByRelevance() {
+    // select and undisable relevance option
+    relevanceSortOption.selected = true;
+    relevanceSortOption.disabled = false;
+    relevanceSortOption.ariaDisabled = false;
+    sortElement.value = relevanceSortOption.value;
+    // set all other options unselected
+    [...sortElement.querySelectorAll("option")]
+        .filter((el) => el.value !== "_score")
+        .forEach((opt) => {
+            opt.selected = false;
+        });
+}
+
+function disableRelevanceSort() {
+    // if relevance sort was selected, set back to default
+    if (relevanceSortOption.selected) {
+        relevanceSortOption.selected = false;
+        defaultSortOption.selected = true;
+        sortElement.value = defaultSortOption.value;
+    }
+    // disable relevance sort
+    relevanceSortOption.disabled = true;
+    relevanceSortOption.ariaDisabled = true;
+}

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -17,6 +17,9 @@
         content="Search Readux volumes"
     />
 {% endblock %}
+{% block extra_javascript %}
+    <script src="{% static 'js/search.js' %}"></script>
+{% endblock %}
 {% block body_class %}template-homepage{% endblock %}
 
 {% block content %}

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -25,6 +25,7 @@
 
     <div>
         <form
+            id="search-form"
             class="uk-form uk-form-stacked uk-width-1-1"
             action="{% url 'search' %}"
             method="get"
@@ -39,6 +40,19 @@
                     Search for individual whole keywords. Multiple words will be searched as
                     'or' (e.g. Rome London = Rome or London). Stopwords (e.g. in, the) will be
                     dropped.
+                </span>
+            </fieldset>
+            <fieldset class="uk-margin uk-flex two-column">
+                <div class="uk-width-1-2">
+                    <div class="uk-form-label">{{ form.author.label }}</div>
+                    {{ form.author }}
+                </div>
+                <div class="uk-width-1-2">
+                    <div class="uk-form-label">{{ form.language.label }}</div>
+                    {{ form.language }}
+                </div>
+                <span class="uk-text-small">
+                    Hold down “Control”, or “Command” on a Mac, to select more than one, or to deselect a selected item. Selecting multiple options will include all results matching any of the options.
                 </span>
             </fieldset>
             <fieldset class="uk-margin uk-width-1-1">

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -68,7 +68,7 @@
     <div class="uk-flex uk-flex-center">
         {% include "snippets/pagination.html" %}
     </div>
-    <ol class="uk-flex uk-flex-column uk-width-1-1@m" id="search-results">
+    <ol class="uk-flex uk-flex-column uk-width-1-1@m uk-list-divider" id="search-results">
         {% for volume in volumes %}
             {% include "snippets/volume_result.html" %}
         {% endfor %}

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -55,6 +55,10 @@
                     Hold down “Control”, or “Command” on a Mac, to select more than one, or to deselect a selected item. Selecting multiple options will include all results matching any of the options.
                 </span>
             </fieldset>
+            <fieldset clas="uk-margin uk-width-1-1">
+                <div class="uk-form-label">{{ form.sort.label }}</div>
+                {{ form.sort }}
+            </fieldset>
             <fieldset class="uk-margin uk-width-1-1">
                 <button class="uk-button uk-button-default" type="submit">
                     Search

--- a/apps/templates/snippets/volume_result.html
+++ b/apps/templates/snippets/volume_result.html
@@ -7,10 +7,10 @@
                 class="nav-link"
                 href="{% url 'volumeall' volume.pid %}"
             >
-                {{ volume.label|default:"No title" }}
+                {{ volume.label|default:"[No label]" }}
             </a>
         {% else %}
-            {{ volume.label|default:"No title" }}
+            {{ volume.label|default:"[No label]" }}
         {% endif %}
     </h4>
     <dl class="uk-description-list">

--- a/apps/templates/snippets/volume_result.html
+++ b/apps/templates/snippets/volume_result.html
@@ -13,7 +13,7 @@
             {{ volume.label|default:"No title" }}
         {% endif %}
     </h4>
-    <dl>
+    <dl class="uk-description-list">
         {% if volume.authors %}
             <dt>Author{{volume.authors|pluralize}}</dt>
             <dd>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -71,3 +71,5 @@ bcp47==0.0.4 # https://github.com/highfestiva/bcp47.py
 # Elasticsearch
 django-elasticsearch-dsl>=7.0.0
 elasticsearch<7.14.0
+# used to unaccent strings for sorting
+unidecode

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -70,3 +70,4 @@ bcp47==0.0.4 # https://github.com/highfestiva/bcp47.py
 
 # Elasticsearch
 django-elasticsearch-dsl>=7.0.0
+elasticsearch<7.14.0


### PR DESCRIPTION
## This PR includes

- Faceted search with applicable filters
  - Facet options: Author, language
  - New form logic to handle faceted fields as multiple-choice selects
- Search sorting ability
  - Sort options: date added (asc/desc), alphabetical (asc/desc), and relevance
  - New keyword index for `label` field for efficient sorting
  - Relevance is disabled unless a query is entered
  - Relevance is automatically selected when typing a query
- Some additional form styling
- Pinned elasticsearch dependency

## Deploy notes

- Since this PR includes changes to indexing logic, it is required to run the following management command after deployment:
  ```sh
  python manage.py search_index --rebuild
  ```
  And enter `y` if prompted to delete the existing index.
- The languages facet will be empty until you start adding languages to manifests, so it is recommended that some are added just in order to populate this facet. (Obviously for dev they can be fake!)