### PR TITLE
Add faceting and filtering on collection label; reorganize UI

### DIFF
--- a/apps/iiif/manifests/documents.py
+++ b/apps/iiif/manifests/documents.py
@@ -55,7 +55,7 @@ class ManifestDocument(Document):
         """convert authors string into list"""
         if instance.author:
             return [s.strip() for s in instance.author.split(";")]
-        return []
+        return ["[no author]"]
 
     def prepare_has_pdf(self, instance):
         """convert pdf field into boolean"""
@@ -66,11 +66,13 @@ class ManifestDocument(Document):
         if instance.label:
             # use unidecode to unaccent characters
             return unidecode(instance.label[0:64], "utf-8")
-        return "[No label]"
+        return "[no label]"
 
     def prepare_languages(self, instance):
         """convert languages into list of strings"""
-        return [lang.name for lang in instance.languages.all()]
+        if instance.languages.count():
+            return [lang.name for lang in instance.languages.all()]
+        return ["[no language]"]
 
     def get_queryset(self):
         """prefetch related to improve performance"""

--- a/apps/iiif/manifests/tests/test_documents.py
+++ b/apps/iiif/manifests/tests/test_documents.py
@@ -23,10 +23,10 @@ class ManifestDocumentTest(ESTestCase, TestCase):
         """Test authors returned as array instead of string"""
         # test no author
         manifest = ManifestFactory.create()
-        assert self.doc.prepare_authors(instance=manifest) == []
+        assert self.doc.prepare_authors(instance=manifest) == ["[no author]"]
         # test empty string
         manifest.author = ""
-        assert self.doc.prepare_authors(instance=manifest) == []
+        assert self.doc.prepare_authors(instance=manifest) == ["[no author]"]
         # test no semicolon
         manifest.author = "test author"
         assert self.doc.prepare_authors(instance=manifest) == ["test author"]
@@ -63,17 +63,17 @@ class ManifestDocumentTest(ESTestCase, TestCase):
         label_alphabetical = self.doc.prepare_label_alphabetical(instance=manifest)
         assert label_alphabetical == random_100_chars[0:64]
         assert len(label_alphabetical) == 64
-        # should return "[No label]" for no label
+        # should return "[no label]" for no label
         manifest.label = ""
-        assert self.doc.prepare_label_alphabetical(instance=manifest) == "[No label]"
+        assert self.doc.prepare_label_alphabetical(instance=manifest) == "[no label]"
         manifest.label = None
-        assert self.doc.prepare_label_alphabetical(instance=manifest) == "[No label]"
+        assert self.doc.prepare_label_alphabetical(instance=manifest) == "[no label]"
 
     def test_prepare_languages(self):
         """Test languages converted into string array"""
         # test no languages
         manifest = ManifestFactory.create()
-        assert self.doc.prepare_languages(instance=manifest) == []
+        assert self.doc.prepare_languages(instance=manifest) == ["[no language]"]
         # test one language
         manifest.languages.add(self.lang_en)
         assert self.doc.prepare_languages(instance=manifest) == ["English"]

--- a/apps/iiif/manifests/tests/test_documents.py
+++ b/apps/iiif/manifests/tests/test_documents.py
@@ -96,3 +96,14 @@ class ManifestDocumentTest(ESTestCase, TestCase):
         # should have one collection, which is the above collection
         assert prefetched['collections'].count() == 1
         assert prefetched['collections'].first().pk == collection.pk
+
+    def test_get_instances_from_related(self):
+        """Should get manifests from related collections"""
+        manifest = ManifestFactory.create()
+        # connect a collection and manifest
+        collection = Collection(label="test collection")
+        collection.save()
+        manifest.collections.add(collection)
+        instances = self.doc.get_instances_from_related(related_instance=collection)
+        # should get the manifest related to this collection
+        self.assertQuerysetEqual(instances, [manifest])

--- a/apps/readux/forms.py
+++ b/apps/readux/forms.py
@@ -12,9 +12,9 @@ class FacetedMultipleChoiceField(forms.MultipleChoiceField):
         self.choices = (
             (
                 bucket["key"],
-                f'{truncatechars(bucket["key"], 64)} ({bucket["doc_count"]})',
+                f'{truncatechars(bucket["key"], 42)} ({bucket["doc_count"]})',
             )
-            for bucket in sorted(buckets, key=lambda b: b["key"]) # sort choices by name
+            for bucket in sorted(buckets, key=lambda b: -b["doc_count"]) # sort choices by count
         )
 
     def valid_value(self, value):

--- a/apps/readux/forms.py
+++ b/apps/readux/forms.py
@@ -55,6 +55,16 @@ class ManifestSearchForm(forms.Form):
             },
         ),
     )
+    collection = FacetedMultipleChoiceField(
+        label="Collection",
+        required=False,
+        widget=forms.SelectMultiple(
+            attrs={
+                "aria-label": "Filter volumes by collection",
+                "class": "uk-input",
+            },
+        ),
+    )
     sort = forms.ChoiceField(
         label="Sort",
         required=False,

--- a/apps/readux/tests/test_forms.py
+++ b/apps/readux/tests/test_forms.py
@@ -22,12 +22,12 @@ class TestFacetedMultipleChoiceField:
         assert ("fake1", "fake1 (0)") in facetfield.choices
         assert ("fake2", "fake2 (12)") in facetfield.choices
 
-        # should truncate keys >= 64 characters for label
+        # should truncate keys >= 42 characters for label
         random_100_chars = ''.join(random.choices(string.ascii_letters, k=100))
         fake_buckets = [{"key": random_100_chars, "doc_count": 120}]
         facetfield.populate_from_buckets(buckets=fake_buckets)
         assert (random_100_chars, f"{random_100_chars} (120)") not in facetfield.choices
-        truncated = f"{random_100_chars[0:63]}…"
+        truncated = f"{random_100_chars[0:41]}…"
         assert (random_100_chars, f"{truncated} (120)") in facetfield.choices
 
 

--- a/apps/readux/views.py
+++ b/apps/readux/views.py
@@ -331,10 +331,10 @@ class VolumeSearchView(ListView, FormMixin):
     # field name for the desired field, and size argument accommodating all possible values)
     facets = [
         # NOTE: This size is set to accommodate all languages, of which there are 830 at present
-        ("language", TermsFacet(field="languages", size=1000, min_doc_count=0)),
+        ("language", TermsFacet(field="languages", size=1000, min_doc_count=1)),
         # TODO: Determine a good size for authors or consider alternate approach (i.e. not faceted)
-        ("author", TermsFacet(field="authors", size=2000, min_doc_count=0)),
-        ("collection", NestedFacet("collections", TermsFacet(field="collections.label", min_doc_count=0)))
+        ("author", TermsFacet(field="authors", size=2000, min_doc_count=1)),
+        ("collection", NestedFacet("collections", TermsFacet(field="collections.label", min_doc_count=1)))
     ]
     defaults = {
         "sort": "label_alphabetical"

--- a/apps/static/css/project.css
+++ b/apps/static/css/project.css
@@ -1652,14 +1652,17 @@ a.nav-link {
 form#search-form input[type="search"][name="q"] {
   width: 100%;
 }
-form#search-form fieldset.two-column {
-  flex-wrap: wrap;
-}
-form#search-form fieldset.two-column div:first-child {
-  padding-right: 1rem;
-}
 
-form#search-form select[multiple] {
+div#search-grid {
+  margin-left: 0;
+}
+div#search-grid :first-child {
+  padding-left: 0;
+}
+div#search-grid :first-child button {
+  padding-left: 30px;
+}
+form#search-filters select[multiple] {
   height: 150px;
   width: 100%;
   overflow-y: scroll;

--- a/apps/static/css/project.css
+++ b/apps/static/css/project.css
@@ -1659,7 +1659,7 @@ form#search-form fieldset.two-column div:first-child {
   padding-right: 1rem;
 }
 
-form#search-form fieldset.two-column select[multiple] {
+form#search-form select[multiple] {
   height: 150px;
   width: 100%;
   overflow-y: scroll;

--- a/apps/static/css/project.css
+++ b/apps/static/css/project.css
@@ -1662,7 +1662,7 @@ div#search-grid :first-child {
 div#search-grid :first-child button {
   padding-left: 30px;
 }
-form#search-filters select[multiple] {
+#search-filters select[multiple] {
   height: 150px;
   width: 100%;
   overflow-y: scroll;

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -26,31 +26,50 @@
     <h1 class="uk-heading-medium uk-text-center">Search</h1>
     <p class="uk-text-lead uk-text-center">Search and filter all volumes.</p>
 
-    <div>
+    <form
+        id="search-form"
+        class="uk-form uk-width-1-1"
+        action="{% url 'search' %}"
+        method="get"
+        accept-charset="utf-8"
+    >
+        <fieldset class="uk-margin uk-width-1-1">
+            <div class="uk-inline uk-width-1-1">
+                <span class="uk-form-icon" uk-icon="icon: search" aria-label="search"></span>
+                {{ form.q }}
+            </div>
+            <span class="uk-text-small">
+                Search for individual whole keywords. Multiple words will be searched as
+                'or' (e.g. Rome London = Rome or London).
+            </span>
+        </fieldset>
+        <fieldset class="uk-margin uk-width-1-1">
+            <div class="uk-form-label">{{ form.sort.label }}</div>
+            {{ form.sort }}
+        </fieldset>
+        <fieldset class="uk-margin uk-flex uk-flex-center uk-width-1-1">
+            <button class="uk-button uk-button-default" type="submit">
+                Search
+            </button>
+        </fieldset>
+    </form>
+    <div uk-grid id="search-grid">
         <form
-            id="search-form"
-            class="uk-form uk-form-stacked uk-width-1-1"
+            id="search-filters"
+            class="uk-form uk-form-stacked uk-width-1-3"
             action="{% url 'search' %}"
             method="get"
             accept-charset="utf-8"
         >
-            <fieldset class="uk-margin uk-width-1-1">
-                <div class="uk-inline uk-width-1-1">
-                    <span class="uk-form-icon" uk-icon="icon: search" aria-label="search"></span>
-                    {{ form.q }}
-                </div>
-                <span class="uk-text-small">
-                    Search for individual whole keywords. Multiple words will be searched as
-                    'or' (e.g. Rome London = Rome or London). Stopwords (e.g. in, the) will be
-                    dropped.
-                </span>
-            </fieldset>
-            <fieldset class="uk-margin uk-flex two-column">
-                <div class="uk-width-1-2">
+            <h4 class="uk-flex uk-flex-center">Filter results</h4>
+            <fieldset class="uk-margin">
+                <div class="uk-width-1-1">
                     <div class="uk-form-label">{{ form.author.label }}</div>
                     {{ form.author }}
                 </div>
-                <div class="uk-width-1-2">
+            </fieldset>
+            <fieldset class="uk-margin">
+                <div class="uk-width-1-1">
                     <div class="uk-form-label">{{ form.language.label }}</div>
                     {{ form.language }}
                 </div>
@@ -63,29 +82,27 @@
                 </span>
             </fieldset>
             <fieldset class="uk-margin uk-width-1-1">
-                <div class="uk-form-label">{{ form.sort.label }}</div>
-                {{ form.sort }}
-            </fieldset>
-            <fieldset class="uk-margin uk-width-1-1">
                 <button class="uk-button uk-button-default" type="submit">
-                    Search
+                    Apply
                 </button>
             </fieldset>
         </form>
-    </div>
-    <div class="uk-flex uk-flex-center uk-margin">
-        {{ volumes.count }} result{{ volumes.count|pluralize }}
-    </div>
-    <div class="uk-flex uk-flex-center">
-        {% include "snippets/pagination.html" %}
-    </div>
-    <ol class="uk-flex uk-flex-column uk-width-1-1@m uk-list-divider" id="search-results">
-        {% for volume in volumes %}
-            {% include "snippets/volume_result.html" %}
-        {% endfor %}
-    </ol>
-    <div class="uk-flex uk-flex-center">
-        {% include "snippets/pagination.html" %}
+        <div class="uk-width-2-3">
+            <h4 class="uk-flex uk-flex-center">
+                {{ volumes.count }} result{{ volumes.count|pluralize }}
+            </h4>
+            <div class="uk-flex uk-flex-center">
+                {% include "snippets/pagination.html" %}
+            </div>
+            <ol class="uk-flex uk-flex-column uk-list-divider" id="search-results">
+                {% for volume in volumes %}
+                    {% include "snippets/volume_result.html" %}
+                {% endfor %}
+            </ol>
+            <div class="uk-flex uk-flex-center">
+                {% include "snippets/pagination.html" %}
+            </div>
+        </div>
     </div>
 
 {% endblock content %}

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -26,83 +26,82 @@
     <h1 class="uk-heading-medium uk-text-center">Search</h1>
     <p class="uk-text-lead uk-text-center">Search and filter all volumes.</p>
 
+
     <form
         id="search-form"
-        class="uk-form uk-width-1-1"
         action="{% url 'search' %}"
         method="get"
         accept-charset="utf-8"
     >
-        <fieldset class="uk-margin uk-width-1-1">
-            <div class="uk-inline uk-width-1-1">
-                <span class="uk-form-icon" uk-icon="icon: search" aria-label="search"></span>
-                {{ form.q }}
-            </div>
-            <span class="uk-text-small">
-                Search for individual whole keywords. Multiple words will be searched as
-                'or' (e.g. Rome London = Rome or London).
-            </span>
-        </fieldset>
-        <fieldset class="uk-margin uk-width-1-1">
-            <div class="uk-form-label">{{ form.sort.label }}</div>
-            {{ form.sort }}
-        </fieldset>
-        <fieldset class="uk-margin uk-flex uk-flex-center uk-width-1-1">
-            <button class="uk-button uk-button-default" type="submit">
-                Search
-            </button>
-        </fieldset>
-    </form>
-    <div uk-grid id="search-grid">
-        <form
-            id="search-filters"
-            class="uk-form uk-form-stacked uk-width-1-3"
-            action="{% url 'search' %}"
-            method="get"
-            accept-charset="utf-8"
-        >
-            <h4 class="uk-flex uk-flex-center">Filter results</h4>
-            <fieldset class="uk-margin">
-                <div class="uk-width-1-1">
-                    <div class="uk-form-label">{{ form.author.label }}</div>
-                    {{ form.author }}
-                </div>
-            </fieldset>
-            <fieldset class="uk-margin">
-                <div class="uk-width-1-1">
-                    <div class="uk-form-label">{{ form.language.label }}</div>
-                    {{ form.language }}
-                </div>
-            </fieldset>
+        <div class="uk-form uk-width-1-1">
             <fieldset class="uk-margin uk-width-1-1">
-                <div class="uk-form-label">{{ form.collection.label }}</div>
-                {{ form.collection }}
+                <div class="uk-inline uk-width-1-1">
+                    <span class="uk-form-icon" uk-icon="icon: search" aria-label="search"></span>
+                    {{ form.q }}
+                </div>
                 <span class="uk-text-small">
-                    Hold down “Control”, or “Command” on a Mac, to select more than one, or to deselect a selected item. Selecting multiple options will include all results matching any of the options.
+                    Search for individual whole keywords. Multiple words will be searched as
+                    'or' (e.g. Rome London = Rome or London).
                 </span>
             </fieldset>
             <fieldset class="uk-margin uk-width-1-1">
+                <div class="uk-form-label">{{ form.sort.label }}</div>
+                {{ form.sort }}
+            </fieldset>
+            <fieldset class="uk-margin uk-flex uk-flex-center uk-width-1-1">
                 <button class="uk-button uk-button-default" type="submit">
-                    Apply
+                    Search
                 </button>
             </fieldset>
-        </form>
-        <div class="uk-width-2-3">
-            <h4 class="uk-flex uk-flex-center">
-                {{ volumes.count }} result{{ volumes.count|pluralize }}
-            </h4>
-            <div class="uk-flex uk-flex-center">
-                {% include "snippets/pagination.html" %}
+        </div>
+        <div uk-grid id="search-grid">
+            <div
+                class="uk-form uk-form-stacked uk-width-1-3"
+                id="search-filters"
+            >
+                <h4 class="uk-flex uk-flex-center">Filter results</h4>
+                <fieldset class="uk-margin">
+                    <div class="uk-width-1-1">
+                        <div class="uk-form-label">{{ form.author.label }}</div>
+                        {{ form.author }}
+                    </div>
+                </fieldset>
+                <fieldset class="uk-margin">
+                    <div class="uk-width-1-1">
+                        <div class="uk-form-label">{{ form.language.label }}</div>
+                        {{ form.language }}
+                    </div>
+                </fieldset>
+                <fieldset class="uk-margin uk-width-1-1">
+                    <div class="uk-form-label">{{ form.collection.label }}</div>
+                    {{ form.collection }}
+                    <span class="uk-text-small">
+                        Hold down “Control”, or “Command” on a Mac, to select more than one, or to deselect a selected item. Selecting multiple options will include all results matching any of the options.
+                    </span>
+                </fieldset>
+                <fieldset class="uk-margin uk-width-1-1">
+                    <button class="uk-button uk-button-default" type="submit">
+                        Apply
+                    </button>
+                </fieldset>
             </div>
-            <ol class="uk-flex uk-flex-column uk-list-divider" id="search-results">
-                {% for volume in volumes %}
-                    {% include "snippets/volume_result.html" %}
-                {% endfor %}
-            </ol>
-            <div class="uk-flex uk-flex-center">
-                {% include "snippets/pagination.html" %}
+            <div class="uk-width-2-3">
+                <h4 class="uk-flex uk-flex-center">
+                    {{ volumes.count }} result{{ volumes.count|pluralize }}
+                </h4>
+                <div class="uk-flex uk-flex-center">
+                    {% include "snippets/pagination.html" %}
+                </div>
+                <ol class="uk-flex uk-flex-column uk-list-divider" id="search-results">
+                    {% for volume in volumes %}
+                        {% include "snippets/volume_result.html" %}
+                    {% endfor %}
+                </ol>
+                <div class="uk-flex uk-flex-center">
+                    {% include "snippets/pagination.html" %}
+                </div>
             </div>
         </div>
-    </div>
+    </form>
 
 {% endblock content %}

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -54,11 +54,15 @@
                     <div class="uk-form-label">{{ form.language.label }}</div>
                     {{ form.language }}
                 </div>
+            </fieldset>
+            <fieldset class="uk-margin uk-width-1-1">
+                <div class="uk-form-label">{{ form.collection.label }}</div>
+                {{ form.collection }}
                 <span class="uk-text-small">
                     Hold down “Control”, or “Command” on a Mac, to select more than one, or to deselect a selected item. Selecting multiple options will include all results matching any of the options.
                 </span>
             </fieldset>
-            <fieldset clas="uk-margin uk-width-1-1">
+            <fieldset class="uk-margin uk-width-1-1">
                 <div class="uk-form-label">{{ form.sort.label }}</div>
                 {{ form.sort }}
             </fieldset>

--- a/apps/templates/snippets/volume_result.html
+++ b/apps/templates/snippets/volume_result.html
@@ -7,14 +7,14 @@
                 class="nav-link"
                 href="{% url 'volumeall' volume.pid %}"
             >
-                {{ volume.label|default:"[No label]" }}
+                {{ volume.label|default:"[no label]" }}
             </a>
         {% else %}
-            {{ volume.label|default:"[No label]" }}
+            {{ volume.label|default:"[no label]" }}
         {% endif %}
     </h4>
     <dl class="uk-description-list">
-        {% if volume.authors %}
+        {% if volume.authors and "[no author]" not in volume.authors %}
             <dt>Author{{volume.authors|pluralize}}</dt>
             <dd>
                 <ul class="uk-margin-remove">
@@ -28,7 +28,7 @@
             <dt>Added</dt>
             <dd>{{volume.created_at}}</dd>
         {% endif %}
-        {% if volume.languages %}
+        {% if volume.languages and "[no language]" not in volume.languages %}
             <dt>Language{{volume.languages|pluralize}}</dt>
             <dd>
                 <ul class="uk-margin-remove">


### PR DESCRIPTION
## What this PR does

- Includes "collections" facet
  - Indexed on `label` field for associated collections
- Adjusts search UI
  - Only shows facets with >= 1 result in the current search
  - Sorts facet lists by matching result count
  - Moves filters to left of search results
- Includes facets for "[no author]" and "[no language]"

## Deploy notes

- Since the collections index has changed, please re-run the management command `python manage.py search_index --rebuild`.