### PR TITLE
Index author field as separate TextField

### DIFF
--- a/apps/iiif/manifests/documents.py
+++ b/apps/iiif/manifests/documents.py
@@ -15,12 +15,14 @@ html_strip = analyzer(
     char_filter=["html_strip"]
 )
 
+
 @registry.register_document
 class ManifestDocument(Document):
     """Elasticsearch Document class for IIIF Manifest"""
 
     # fields to map explicitly in Elasticsearch
-    authors = fields.KeywordField(multi=True)
+    authors = fields.KeywordField(multi=True)  # only used for faceting/filtering
+    author = fields.TextField()  # only used for searching
     collections = fields.NestedField(properties={
         "label": fields.KeywordField(),
     })
@@ -60,7 +62,7 @@ class ManifestDocument(Document):
     def prepare_has_pdf(self, instance):
         """convert pdf field into boolean"""
         return bool(instance.pdf)
-    
+
     def prepare_label_alphabetical(self, instance):
         """get the first 64 chars of a label, just for sorting purposes"""
         if instance.label:

--- a/apps/readux/views.py
+++ b/apps/readux/views.py
@@ -324,7 +324,7 @@ class VolumeSearchView(ListView, FormMixin):
     context_object_name = "volumes"
     paginate_by = 25
     # default fields to search when using query box; ^ with number indicates a boosted field
-    query_search_fields = ["pid", "label^5", "summary^2", "authors"]
+    query_search_fields = ["pid", "label^5", "summary^2", "author"]
 
     # Facet fields: tuples of (name, facet) where "name" matches the form field name,
     # and "facet" is an Elasticsearch facet (with field argument matching the ManifestDocument


### PR DESCRIPTION
## What this PR does

- Indexes the original `author` field, unparsed, as a searchable text field—fixing bug that prevented authors from being searched properly in the query box
  - Leaves the second `authors` field (where authors are separately indexed for faceting) alone

## Deploy notes

- Since indexing has changed, as usual, the management command `python manage.py search_index --rebuild` will need to be run after deployment.