### PR TITLE
Handle canvas creation from manifests that use "items" vs "sequences"

### DIFF
--- a/apps/ingest/models.py
+++ b/apps/ingest/models.py
@@ -424,9 +424,17 @@ class Remote(IngestAbstractModel):
     @property
     def image_server(self):
         """ Image server the Manifest """
-        iiif_url = services.extract_image_server(
-            self.remote_manifest['sequences'][0]['canvases'][0]
-        )
+        manifest_keys = self.remote_manifest.keys()
+        if 'sequences' in manifest_keys:
+            iiif_url = services.extract_image_server(
+                self.remote_manifest['sequences'][0]['canvases'][0],
+                'sequences'
+            )
+        elif 'items' in manifest_keys:
+            iiif_url = services.extract_image_server(
+                self.remote_manifest["items"][0]["items"][0]["items"][0],
+                'items'
+            )
         server, _created = ImageServer.objects.get_or_create(server_base=iiif_url)
 
         return server

--- a/apps/ingest/services.py
+++ b/apps/ingest/services.py
@@ -77,15 +77,20 @@ def create_manifest(ingest):
 
     return manifest
 
-def extract_image_server(canvas):
+def extract_image_server(canvas, type):
     """Determines the IIIF image server URL for a given IIIF Canvas
 
     :param canvas: IIIF Canvas
     :type canvas: dict
+    :param type: IIIF Canvas listing type ('sequences' or 'items')
+    :type type: str
     :return: IIIF image server URL
     :rtype: str
     """
-    url = urlparse(canvas['images'][0]['resource']['service']['@id'])
+    if type == 'sequences':
+        url = urlparse(canvas['images'][0]['resource']['service']['@id'])
+    elif type == 'items':
+        url = urlparse(canvas["body"]["service"][0]["@id"])
     parts = url.path.split('/')
     parts.pop()
     base_path = '/'.join(parts)


### PR DESCRIPTION
This PR does the following:
* Handles canvas creation from remote manifests that use "items" vs "sequences" (such as [this one](https://collections.library.yale.edu/manifests/11007468))

Related Trello card:

<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;YyFi4CUv&#x2F;113-remote-ingest-ingest-tweaks-see-checklist-in-card-as-an-admin-i-want-to-be-able-to-insert-a-iiif-link-to-volumes-manifest-hosted">Remote ingest - ingest tweaks - See Checklist in card - As an admin, I want to be able to insert a iiif link to volume(s)&#39; manifest hosted outside Emory Libraries and ingest the volume into Readux.</a></blockquote>

