### PR TITLE
Improve form validation and casefolding for s3 ingest

### DIFF
--- a/apps/ingest/services.py
+++ b/apps/ingest/services.py
@@ -192,4 +192,7 @@ def get_associated_meta(all_metadata, file):
 
 def lowercase_first_line(iterator):
     """Lowercase the first line of a text file (such as the header row of a CSV)"""
-    return itertools.chain([next(iterator).lower()], iterator)
+    return itertools.chain(
+        # ignore unicode characters, set lowercase, and strip whitespace
+        [next(iterator).encode('ascii', 'ignore').decode().casefold().strip()], iterator
+    )


### PR DESCRIPTION
## In this PR

- Catch and display a couple of common errors that would previously silently fail: user provided URL for s3 bucket name, user provided a spreadsheet without a PID column.
- Improve handling of spreadsheets to strip out unicode and whitespace, and use `casefold` instead of `lower`