### PR TITLE
Full text OCR search across all volumes (#944, #945)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,7 +146,6 @@ assets/upload/*
 !assets/upload/index.html
 
 *_dev
-snippets
 
 # profiler
 *.profile

--- a/apps/cms/templatetags/readux_templatetags.py
+++ b/apps/cms/templatetags/readux_templatetags.py
@@ -2,7 +2,23 @@ from django.template import Library
 
 register = Library()
 
+
 @register.filter_function
 def order_by(queryset, args):
-    args = [x.strip() for x in args.split(',')]
+    args = [x.strip() for x in args.split(",")]
     return queryset.order_by(*args)
+
+
+@register.filter
+def dict_item(dictionary, key):
+    """'Template filter to allow accessing dictionary value by variable key.
+    Example use::
+
+        {{ mydict|dict_item:keyvar }}
+    """
+    # adapted from Princeton-CDH/geniza project https://github.com/Princeton-CDH/geniza/
+    try:
+        return dictionary[key]
+    except AttributeError:
+        # fail silently if something other than a dict is passed
+        return None

--- a/apps/iiif/canvases/management/commands/rebuild_ocr.py
+++ b/apps/iiif/canvases/management/commands/rebuild_ocr.py
@@ -123,4 +123,5 @@ class Command(BaseCommand):
                     anno.content = word['content']
                     anno.save()
                     prog_bar.next()
+                canvas.save()
                 prog_bar.finish()

--- a/apps/iiif/canvases/tasks.py
+++ b/apps/iiif/canvases/tasks.py
@@ -16,6 +16,7 @@ def add_ocr_task(canvas_id, *args, **kwargs):
 
     if ocr is not None:
         add_ocr_annotations(canvas, ocr)
+        canvas.save()  # trigger reindex
 
 @app.task(name='adding_oa_ocr_to_canvas', retry_backoff=5)
 def add_oa_ocr_task(annotation_list_url):

--- a/apps/iiif/manifests/documents.py
+++ b/apps/iiif/manifests/documents.py
@@ -32,7 +32,6 @@ class ManifestDocument(Document):
         properties={
             "result": fields.TextField(analyzer=stemmer),
             "position": fields.IntegerField(),
-            "thumbnail": fields.KeywordField(),
             "pid": fields.KeywordField(),
         }
     )  # canvas_set.result = OCR annotation text on each canvas

--- a/apps/iiif/manifests/documents.py
+++ b/apps/iiif/manifests/documents.py
@@ -67,7 +67,7 @@ class ManifestDocument(Document):
             "publisher",
             "viewingdirection",
         ]
-        related_models = [Collection, Canvas, Annotation]
+        related_models = [Collection, Canvas]
 
     def prepare_authors(self, instance):
         """convert authors string into list"""
@@ -125,6 +125,3 @@ class ManifestDocument(Document):
         elif isinstance(related_instance, Canvas):
             # many to many relationship
             return related_instance.manifest
-        elif isinstance(related_instance, Annotation):
-            # many to many relationship
-            return related_instance.canvas.manifest

--- a/apps/readux/forms.py
+++ b/apps/readux/forms.py
@@ -57,6 +57,21 @@ class ManifestSearchForm(forms.Form):
             },
         ),
     )
+    scope = forms.ChoiceField(
+        label="Limit search to",
+        required=False,
+        initial="all",
+        choices=(
+            ("all", "All"),
+            ("metadata", "Metadata only"),
+            ("text", "Textual contents only"),
+        ),
+        widget=forms.Select(
+            attrs={
+                "class": "uk-select",
+            },
+        ),
+    )
     language = FacetedMultipleChoiceField(
         label="Language",
         required=False,

--- a/apps/readux/views.py
+++ b/apps/readux/views.py
@@ -431,9 +431,11 @@ class VolumeSearchView(ListView, FormMixin):
                     inner_hits={
                         "name": "canvases",
                         "size": 3,  # max number of pages shown in full-text results
-                        "sort": [{"canvas_set.position": {"order": "asc"}}],
                         "highlight": {"fields": {"canvas_set.result": {}}},
                     },
+                    # sum scores if in full text only search, so vols with most hits show up first.
+                    # if also searching metadata, use avg (default) instead, to not over-inflate.
+                    score_mode="sum" if scope == "text" else "avg",
                 )
                 queries.append(nested_query)
 

--- a/apps/readux/views.py
+++ b/apps/readux/views.py
@@ -407,42 +407,72 @@ class VolumeSearchView(ListView, FormMixin):
         form_data = form.cleaned_data
 
         # default to empty string if no query in form data
-        search_query = form_data.get("q", "")
+        search_query = form_data.get("q") or ""
+        scope = form_data.get("scope") or "all"
         if search_query:
-            multimatch_query = MultiMatch(query=search_query, fields=self.query_search_fields)
-            volumes = volumes.query(multimatch_query)
+            queries = []
+            if scope in ["all", "metadata"]:
+                # query for root level fields
+                multimatch_query = Q(
+                    "multi_match", query=search_query, fields=self.query_search_fields
+                )
+                queries.append(multimatch_query)
+            
+            if scope in ["all", "text"]:
+                # query for nested fields (i.e. canvas position and text)
+                nested_query = Q(
+                    "nested",
+                    path="canvas_set",
+                    query=Q(
+                        "multi_match",
+                        query=search_query,
+                        fields=["canvas_set.result"],
+                    ),
+                    inner_hits={
+                        "name": "canvases",
+                        "size": 3,  # max number of pages shown in full-text results
+                        "sort": [{"canvas_set.position": {"order": "asc"}}],
+                        "highlight": {"fields": {"canvas_set.result": {}}},
+                    },
+                )
+                queries.append(nested_query)
+
+            # combine them with bool: { should }
+            q = Q("bool", should=queries)
+            volumes = volumes.query(q)
 
         # highlight
         volumes = volumes.highlight_options(
             require_field_match=False,
             fragment_size=200,
             number_of_fragments=10,
+            max_analyzed_offset=999999,
         ).highlight(
             "label", "author", "summary"
         )
 
         # filter on authors
-        author_filter = form_data.get("author", "")
+        author_filter = form_data.get("author") or ""
         if author_filter:
             volumes = volumes.filter("terms", authors=author_filter)
 
         # filter on languages
-        language_filter = form_data.get("language", "")
+        language_filter = form_data.get("language") or ""
         if language_filter:
             volumes = volumes.filter("terms", languages=language_filter)
 
         # filter on collections
-        collection_filter = form_data.get("collection", "")
+        collection_filter = form_data.get("collection") or ""
         if collection_filter:
             volumes = volumes.filter("nested", path="collections", query=Q(
                 "terms", **{"collections.label": collection_filter}
             ))
 
         # filter on date published
-        min_date_filter = form_data.get("start_date", "")
+        min_date_filter = form_data.get("start_date") or ""
         if min_date_filter:
             volumes = volumes.filter("range", date_earliest={"gte": min_date_filter})
-        max_date_filter = form_data.get("end_date", "")
+        max_date_filter = form_data.get("end_date") or ""
         if max_date_filter:
             volumes = volumes.filter("range", date_latest={"lte": max_date_filter})
 

--- a/apps/static/css/project.css
+++ b/apps/static/css/project.css
@@ -41,6 +41,20 @@ em {
   border: 1px solid transparent;
 }
 
+#search-form .scope-and-keyword {
+  display: flex;
+  flex-flow: row nowrap;
+  margin: 1rem 0 0;
+  gap: 0.5rem;
+}
+
+#search-form .scope-and-keyword .scope {
+ flex: 0 1 auto;
+}
+#search-form .scope-and-keyword .keyword {
+  flex: 1 0 auto;
+}
+
 .uk-tab > .uk-active > a {
   border-color: var(--link-color) !important;
   color: var(--link-color) !important; }
@@ -1829,11 +1843,34 @@ ol#search-results dl {
   margin-left: 2rem; }
 
 /* Clamp summary to 3 lines */
-ol#search-results dd.result-volume-summary {
+ol#search-results .result-volume-summary {
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   overflow: hidden; }
+
+/* search result highlighting */
+ol#search-results em {
+  color: #510029 !important;
+  font-weight: bold;
+  font-style: normal; }
+
+/* results within full text */
+ol#search-results .result-page a {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+  align-items: center;
+  font-size: 0.8rem;
+  gap: 1rem;
+  padding: 0.25rem 1rem; }
+
+ol#search-results .result-page .page-number {
+  min-width: 2rem;
+  max-width: 2rem;}
+ol#search-results .result-page img {
+  max-width: 100px;
+  max-height: 100px; }
 
 .sr-only {
   position: absolute;

--- a/apps/static/css/project.css
+++ b/apps/static/css/project.css
@@ -1860,17 +1860,20 @@ ol#search-results .result-page a {
   display: flex;
   flex-flow: row nowrap;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   font-size: 0.8rem;
   gap: 1rem;
-  padding: 0.25rem 1rem; }
+  margin: 0.5rem 0;
+}
 
 ol#search-results .result-page .page-number {
-  min-width: 2rem;
-  max-width: 2rem;}
-ol#search-results .result-page img {
-  max-width: 100px;
-  max-height: 100px; }
+  min-width: 4rem;
+  max-width: 4rem;
+}
+
+ol#search-results .result-page ul li {
+  list-style: disc;
+}
 
 .sr-only {
   position: absolute;

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -48,16 +48,21 @@
         accept-charset="utf-8"
     >
         <div class="uk-form uk-width-1-1">
-            <fieldset class="uk-margin uk-width-1-1">
-                <div class="uk-inline uk-width-1-1">
-                    <span class="uk-form-icon" uk-icon="icon: search" aria-label="search"></span>
-                    {{ form.q }}
+            <fieldset class="uk-margin uk-width-1-1 scope-and-keyword">
+                <div class="scope">
+                    {{ form.scope }}
                 </div>
-                <span class="uk-text-small">
-                    Search for individual whole keywords. Multiple words will be searched as
-                    'or' (e.g. Rome London = Rome or London).
-                </span>
+                <div class="keyword">
+                    <div class="uk-inline uk-width-1-1">
+                        <span class="uk-form-icon" uk-icon="icon: search" aria-label="search"></span>
+                        {{ form.q }}
+                    </div>
+                </div>
             </fieldset>
+            <span class="uk-text-small">
+                Search for individual whole keywords. Multiple words will be searched as
+                'or' (e.g. Rome London = Rome or London).
+            </span>
             <fieldset class="uk-margin uk-width-1-1">
                 <div class="uk-form-label">{{ form.sort.label }}</div>
                 {{ form.sort }}

--- a/apps/templates/snippets/volume_result.html
+++ b/apps/templates/snippets/volume_result.html
@@ -1,3 +1,4 @@
+{% load readux_templatetags %}
 
 <li class="uk-width-1-1@m uk-margin-small">
     <h4>
@@ -7,7 +8,7 @@
                 class="nav-link"
                 href="{% url 'volumeall' volume.pid %}"
             >
-                {% if volume.meta.highlight.label %}
+                {% if 'highlight' in volume.meta and volume.meta.highlight.label %}
                     {% for fragment in volume.meta.highlight.label %}
                         {{ fragment|safe }}
                     {% endfor %}
@@ -16,7 +17,7 @@
                 {% endif %}
             </a>
         {% else %}
-            {% if volume.meta.highlight.label %}
+            {% if 'highlight' in volume.meta and volume.meta.highlight.label %}
                 {% for fragment in volume.meta.highlight.label %}
                     {{ fragment|safe }}
                 {% endfor %}
@@ -34,7 +35,7 @@
             <dt>Author{{volume.authors|pluralize}}</dt>
             <dd>
                 <ul class="uk-margin-remove">
-                    {% if volume.meta.highlight.author %}
+                    {% if 'highlight' in volume.meta and volume.meta.highlight.author %}
                         {% for fragment in volume.meta.highlight.author %}
                             {{ fragment|safe }}
                         {% endfor %}
@@ -63,7 +64,7 @@
         {% if volume.summary %}
             <dt>Summary</dt> 
             <dd class="result-volume-summary">
-                {% if volume.meta.highlight.summary %}
+                {% if 'highlight' in volume.meta and volume.meta.highlight.summary %}
                     {% for fragment in volume.meta.highlight.summary %}
                         {{ fragment|safe }}
                     {% endfor %}
@@ -71,6 +72,24 @@
                     {{ volume.summary|safe }}
                 {% endif %}
             </dd>
+        {% endif %}
+        {% if 'inner_hits' in volume.meta and volume.meta.inner_hits.canvases.hits.total.value %}
+            <dt>Full Text</dt> 
+            {% for canvas in volume.meta.inner_hits.canvases %}
+                <dd class="result-page">
+                    <a href="{% url 'page' volume=volume.pid page=canvas.pid %}">
+                        <span class="page-number">{{ canvas.position|add:1 }}</span>
+                        {% if canvas.thumbnail %}<img src="{{ canvas.thumbnail }}" loading="lazy" />{% endif %}
+                        {% if canvas.meta.highlight %}
+                            <ul class="highlights">
+                            {% for fragment in canvas.meta.highlight|dict_item:"canvas_set.result" %}
+                                <li class="result-volume-summary">{{ fragment|safe }}</li>
+                            {% endfor %}
+                            </ul>
+                        {% endif %}
+                    </a>
+                </dd>
+            {% endfor %}
         {% endif %}
     </dl>
 </li>

--- a/apps/templates/snippets/volume_result.html
+++ b/apps/templates/snippets/volume_result.html
@@ -78,12 +78,11 @@
             {% for canvas in volume.meta.inner_hits.canvases %}
                 <dd class="result-page">
                     <a href="{% url 'page' volume=volume.pid page=canvas.pid %}">
-                        <span class="page-number">{{ canvas.position|add:1 }}</span>
-                        {% if canvas.thumbnail %}<img src="{{ canvas.thumbnail }}" loading="lazy" />{% endif %}
+                        <span class="page-number">p. {{ canvas.position|add:1 }}</span>
                         {% if canvas.meta.highlight %}
                             <ul class="highlights">
                             {% for fragment in canvas.meta.highlight|dict_item:"canvas_set.result" %}
-                                <li class="result-volume-summary">{{ fragment|safe }}</li>
+                                <li>{{ fragment|safe }}</li>
                             {% endfor %}
                             </ul>
                         {% endif %}


### PR DESCRIPTION
## In this PR

Per #944:
- Index full OCR text for all documents, with stemming
- Add searching and highlighting on that field to view and template

Per #945:
- In indexing, account for multiple hits within the same full text by nesting canvas within document, and including page numbers and ids with each canvas
- In frontend, group them together by page number, and link each result to individual page
- Limit to top 3 pages in a volume sorted by score

## Notes

This will require a reindex with Elastic. The command is:

```sh
python manage.py search_index --rebuild
```

I have a couple of questions about this:
1. This is going to create quite a large index because it has to index the full text with analysis of every document. It also might eat up significant resources while creating the index. Do you have a way of testing this in a similar environment to prod, or would that just be the dev server? I would be curious about any space or hardware limitations that you run into and if there end up being errors.
   - FWIW, I tried to improve the prefetching, but I was having trouble telling if it was working or not locally.
2. Would it be helpful to have somewhere to track systems tasks like this that need to be done on deployment, by version number, like a "deploy notes" file? Or is there already a mechanism somewhere for that?
