### PR TITLE
Don't add 1 to canvas position in search results (#945)

### DIFF
--- a/apps/ingest/models.py
+++ b/apps/ingest/models.py
@@ -452,7 +452,7 @@ class Remote(IngestAbstractModel):
 
     def create_canvases(self):
         # TODO: What if there are multiple sequences? Is that even allowed in IIIF?
-        for position, sc_canvas in enumerate(self.remote_manifest['sequences'][0]['canvases']):
+        for position, sc_canvas in enumerate(self.remote_manifest['sequences'][0]['canvases'], start=1):
             canvas_metadata = None
             # TODO: we will need some sort of check for IIIF API version, but not
             # everyone includes a context for each canvas.

--- a/apps/templates/snippets/volume_result.html
+++ b/apps/templates/snippets/volume_result.html
@@ -78,7 +78,7 @@
             {% for canvas in volume.meta.inner_hits|group_by_canvas %}
                 <dd class="result-page">
                     <a href="{% url 'page' volume=volume.pid page=canvas.pid %}">
-                        <span class="page-number">p. {{ canvas.position|add:1 }}</span>
+                        <span class="page-number">p. {{ canvas.position }}</span>
                         {% if canvas.highlights|length %}
                             <ul class="highlights">
                             {% for fragment in canvas.highlights %}


### PR DESCRIPTION
## In this PR

Per #945:
- Removes `add:1` from position attributes for page numbers in search results

Per #1000:
- On remote ingest, start enumeration of canvases at 1

Note that #1000 will explain why some are off by 1 after this change. A migration would be needed to fix the wrong entries that exist currently.