### PR TITLE
Allow ingest of metadata not in model fields, add custom metadata facets to search (#960)

### DIFF
--- a/apps/iiif/serializers/manifest.py
+++ b/apps/iiif/serializers/manifest.py
@@ -27,6 +27,17 @@ class Serializer(JSONSerializer):
     def end_serialization(self):
         self.stream.write('')
 
+    def serialize_metadata(self, obj):
+        """Convert metadata on object into list of {label, value} dicts"""
+        if isinstance(obj.metadata, list):
+            # most common case: metadata is already a list of {label, value} dicts
+            return obj.metadata
+        elif isinstance(obj.metadata, dict):
+            # convert dict into list of label/value pair dicts
+            return [{"label": key, "value": val} for (key, val) in obj.metadata.items()]
+        else:
+            return []
+
     def get_dump_object(self, obj):
         # TODO: Raise error if version is not v2 or v3
         if self.version == 'v2' or self.version is None:
@@ -70,10 +81,6 @@ class Serializer(JSONSerializer):
                         "value": obj.published_date
                     },
                     {
-                        "label": "Notes",
-                        "value": obj.metadata
-                    },
-                    {
                         "label": "Record Created",
                         "value": obj.created_at
                     },
@@ -92,7 +99,9 @@ class Serializer(JSONSerializer):
                     {
                         "label": "Export Date",
                         "value": self.exportdate
-                    }
+                    },
+                    # unpack serialized metadata (list of label, value pairs)
+                    *self.serialize_metadata(obj),
                 ],
                 "description": obj.summary,
                 "related": obj.related_links,

--- a/apps/ingest/admin.py
+++ b/apps/ingest/admin.py
@@ -18,7 +18,7 @@ from apps.ingest import tasks
 from .forms import BulkVolumeUploadForm
 from .models import Bulk, IngestTaskWatcher, Local, Remote, S3Ingest
 from .services import (clean_metadata, create_manifest, get_associated_meta,
-                       get_metadata_from, lowercase_first_line)
+                       get_metadata_from, normalize_header)
 
 LOGGER = logging.getLogger(__name__)
 class LocalAdmin(admin.ModelAdmin):
@@ -253,7 +253,7 @@ class S3IngestForm(forms.ModelForm):
         csv_file = self.cleaned_data.get('metadata_spreadsheet')
         if csv_file:
             reader = csv.DictReader(
-                lowercase_first_line(
+                normalize_header(
                     StringIO(csv_file.read().decode('utf-8'))
                 ),
             )
@@ -284,7 +284,7 @@ class S3IngestAdmin(admin.ModelAdmin):
         # Get spreadsheet with metadata to match each volume
         obj.metadata_spreadsheet.seek(0)
         metadata = csv.DictReader(
-            lowercase_first_line(
+            normalize_header(
                 StringIO(obj.metadata_spreadsheet.read().decode('utf-8'))
             ),
         )

--- a/apps/ingest/forms.py
+++ b/apps/ingest/forms.py
@@ -7,5 +7,5 @@ class BulkVolumeUploadForm(forms.ModelForm):
         model = Bulk
         fields = ['image_server', 'volume_files', 'collections']
         widgets = {
-            'volume_files': ClearableFileInput(attrs={'allow_multiple_selected': True}),
+            'volume_files': ClearableFileInput(attrs={'allow_multiple_selected': True, 'multiple': True}),
         }

--- a/apps/ingest/forms.py
+++ b/apps/ingest/forms.py
@@ -2,10 +2,15 @@ from django import forms
 from django.forms import ClearableFileInput
 from .models import Bulk
 
+
+class MultipleFileInput(forms.ClearableFileInput):
+    allow_multiple_selected = True
+
+
 class BulkVolumeUploadForm(forms.ModelForm):
     class Meta:
         model = Bulk
-        fields = ['image_server', 'volume_files', 'collections']
+        fields = ["image_server", "volume_files", "collections"]
         widgets = {
-            'volume_files': ClearableFileInput(attrs={'allow_multiple_selected': True, 'multiple': True}),
+            "volume_files": MultipleFileInput,
         }

--- a/apps/ingest/tasks.py
+++ b/apps/ingest/tasks.py
@@ -17,7 +17,7 @@ from apps.iiif.canvases.models import Canvas
 from apps.ingest.models import IngestTaskWatcher
 
 from .mail import send_email_on_failure, send_email_on_success
-from .services import create_manifest, create_related_links
+from .services import create_manifest, create_related_links, set_metadata
 
 # Use `apps.get_model` to avoid circular import error. Because the parameters used to
 # create a background task have to be serializable, we can't just pass in the model object.
@@ -128,13 +128,7 @@ def create_canvases_from_s3_ingest(metadata, ingest_id):
         manifest = Manifest.objects.get(pid=pid)
     except Manifest.DoesNotExist:
         manifest = Manifest.objects.create(pid=pid)
-    for (key, value) in metadata.items():
-        if key == "related":
-            # add RelatedLinks from metadata spreadsheet key "related"
-            create_related_links(manifest, value)
-        else:
-            # all other keys should exist as fields on Manifest (for now)
-            setattr(manifest, key, value)
+    set_metadata(manifest, metadata)
     # Image server: set from ingest
     ingest = S3Ingest.objects.get(pk=ingest_id)
     manifest.image_server = ingest.image_server

--- a/apps/ingest/tests/test_local.py
+++ b/apps/ingest/tests/test_local.py
@@ -321,15 +321,15 @@ class LocalTest(TestCase):
     #     except Local.DoesNotExist:
     #         pass
 
-    def test_it_creates_mainfest_with_metadata_property(self):
+    def test_it_creates_manifest_with_metadata_property(self):
         metadata = {
             'pid': '808',
-            'title': 'Goodie Mob'
+            'label': 'Goodie Mob'
         }
         local = self.mock_local('no_meta_file.zip', metadata=metadata)
         local.manifest = create_manifest(local)
         assert local.manifest.pid == '808'
-        assert local.manifest.title == 'Goodie Mob'
+        assert local.manifest.label == 'Goodie Mob'
 
     def test_create_related_links(self):
         metadata = {

--- a/apps/ingest/tests/test_remote.py
+++ b/apps/ingest/tests/test_remote.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from apps.iiif.manifests.tests.factories import ManifestFactory
 from .factories import RemoteFactory
 from ..services import (clean_metadata, create_manifest, get_associated_meta,
-                       get_metadata_from, lowercase_first_line)
+                       get_metadata_from, normalize_header)
 
 
 class RemoteTest(TestCase):

--- a/apps/ingest/tests/test_s3.py
+++ b/apps/ingest/tests/test_s3.py
@@ -17,7 +17,7 @@ from .mock_sftp import MockSFTP
 from apps.iiif.manifests.tests.factories import ManifestFactory, ImageServerFactory
 from ..models import S3Ingest
 from ..services import (clean_metadata, create_manifest, get_associated_meta,
-                       get_metadata_from, lowercase_first_line)
+                       get_metadata_from, normalize_header)
 
 pytestmark = pytest.mark.django_db(transaction=True) # pylint: disable = invalid-name
 

--- a/apps/ingest/tests/test_services.py
+++ b/apps/ingest/tests/test_services.py
@@ -21,8 +21,7 @@ class ServicesTest(TestCase):
         self.fixture_path = os.path.join(settings.APPS_DIR, 'ingest/fixtures/')
 
     def test_cleaning_metadata(self):
-        """ It should normalize keys and remove key/value pairs that
-        do not match a Manifest field. """
+        """ It should normalize keys that match a Manifest field. """
         fake_metadata = {
             'pid': 'blm',
             'invalid': 'trump',
@@ -40,7 +39,6 @@ class ServicesTest(TestCase):
 
         assert 'Published City' not in cleaned_metadata.keys()
         assert 'PUBLISHER' not in cleaned_metadata.keys()
-        assert 'invalid' not in cleaned_metadata.keys()
         assert cleaned_metadata['published_city'] == fake_metadata['Published City']
         assert cleaned_metadata['publisher'] == fake_metadata['PUBLISHER']
 

--- a/apps/ingest/tests/test_services.py
+++ b/apps/ingest/tests/test_services.py
@@ -32,11 +32,6 @@ class ServicesTest(TestCase):
 
         cleaned_metadata = services.clean_metadata(fake_metadata)
 
-        manifest_fields = [f.name for f in Manifest._meta.get_fields()]
-
-        for key in cleaned_metadata.keys():
-            assert key in manifest_fields
-
         assert 'Published City' not in cleaned_metadata.keys()
         assert 'PUBLISHER' not in cleaned_metadata.keys()
         assert cleaned_metadata['published_city'] == fake_metadata['Published City']

--- a/apps/readux/forms.py
+++ b/apps/readux/forms.py
@@ -2,6 +2,7 @@
 
 from dateutil import parser
 from django import forms
+from django.conf import settings
 from django.template.defaultfilters import truncatechars
 
 
@@ -139,12 +140,41 @@ class ManifestSearchForm(forms.Form):
         )
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # pull additional facets from Elasticsearch
+        if (
+            settings
+            and hasattr(settings, "CUSTOM_METADATA")
+            and isinstance(settings.CUSTOM_METADATA, dict)
+        ):
+            # should be a dict like {meta_key: {"multi": bool, "separator": str}}
+            for key in settings.CUSTOM_METADATA.keys():
+                self.fields[
+                    # use django-friendly form field names
+                    key.casefold().replace(" ", "_")
+                ] = FacetedMultipleChoiceField(
+                    label=key,
+                    required=False,
+                    widget=forms.SelectMultiple(
+                        attrs={
+                            "aria-label": f"Filter volumes by {key}",
+                            "class": "uk-input",
+                        },
+                    ),
+                )
+
     def set_facets(self, facets):
         """Use facets from Elasticsearch to populate form fields"""
         for name, buckets in facets.items():
             if name in self.fields:
                 # Assumes that name passed in the view's facets list matches form field name
                 self.fields[name].populate_from_buckets(buckets)
+            elif name.casefold().replace(" ", "_") in self.fields:
+                self.fields[name.casefold().replace(" ", "_")].populate_from_buckets(
+                    buckets
+                )
 
     def set_date(self, min_date, max_date):
         """Use min and max aggregations from Elasticsearch to populate date range fields"""

--- a/apps/readux/templatetags/readux_extras.py
+++ b/apps/readux/templatetags/readux_extras.py
@@ -5,6 +5,20 @@ register = Library()
 
 
 @register.filter
+def dict_item(dictionary, key):
+    """'Template filter to allow accessing dictionary value by variable key.
+    Example use::
+
+        {{ mydict|dict_item:keyvar }}
+    """
+    # adapted from Princeton-CDH/geniza project https://github.com/Princeton-CDH/geniza/
+    try:
+        return dictionary[key]
+    except AttributeError:
+        # fail silently if something other than a dict is passed
+        return None
+    
+@register.filter
 def has_inner_hits(volume):
     """Template filter to determine if there are any inner hits across the volume"""
     try:

--- a/apps/templates/search_results.html
+++ b/apps/templates/search_results.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags static %}
+{% load wagtailcore_tags static readux_extras %}
 
 {% block extra_head %}
     <meta property="og:title" content="Readux - Search" />
@@ -112,6 +112,16 @@
                         {{ form.end_date }}
                     </noscript>
                 </fieldset>
+                {% for key in CUSTOM_METADATA_KEYS %}
+                    <fieldset class="uk-margin">
+                        <div class="uk-width-1-1">
+                            {% with form|dict_item:key as field %}
+                                <div class="uk-form-label">{{ field.label }}</div>
+                                {{ field }}
+                            {% endwith %}
+                        </div>
+                    </fieldset>
+                {% endfor %}
                 <fieldset class="uk-margin uk-width-1-1 uk-flex uk-flex-between">
                     <button id="reset-filters" class="uk-button uk-button-danger" type="button">
                         Reset filters

--- a/config/settings/local.dst
+++ b/config/settings/local.dst
@@ -171,3 +171,24 @@ LOGGING = {
 
 # Must be configured to the host and port running Elasticsearch
 ELASTICSEARCH_DSL['default']['hosts'] = 'user:pass@localhost:9200'
+
+# Custom faceted metadata fields configuration. Must be a dict with key names
+# matching exactly the ingest metadata spradsheet column names to be indexed.
+# For each column, configure options for whether it should accept multiple
+# values in a single record ("multi": True), and if so, what separator will be
+# used ("separator": ";", semicolon by default).
+# Note that these key names will also correspond to "label" names in the Manifest
+# metadata list.
+# 
+# Example:
+# CUSTOM_METADATA = {
+#     "Column Name": {
+#         "multi": True,
+#         "separator": ";",
+#     },
+#     "Other Column": {
+#         "multi": False,
+#     },
+# }
+
+CUSTOM_METADATA = {}


### PR DESCRIPTION
## In this PR

Per #960:
- Allow ingest of metadata fields that are not equivalent to existing model fields
  - These populate `Manifest.metadata` as a list of `"label"` and `"value"` pair dicts
- Reorganize the IIIF serializer to use the `Manifest.metadata` JSON as `"metadata"` field entries instead of nested inside `"label": "Notes"` (?)
- Allow faceted searching of fields specified in local settings
  - For dynamic mapping in the search index, use Keyword as default for strings instead of Text, so that custom metadata fields can be dynamically mapped to facet-able fields. (This also required moving dynamically mapped TextFields to explicitly mapped ones)
  - Dynamically add search backend support, form fields, and UI elements for custom facets

Other:
- I also fixed the multiple file input in the bulk ingest upload.

## Notes

Let me know if the `settings.CUSTOM_METADATA` spec isn't clear enough in `local.dst`. The basic idea is that it's a dict with keys matching metadata spreadsheet column names. The value of each key will be an options dict indicating whether or not that column must allow multiple values (`"multi"` boolean) and if so, what the separator character should be (`"separator"`, default `";"`). 