### PR TITLE
Bugfix: Reader JS/CSS errors

### DIFF
--- a/apps/static/css/project.scss
+++ b/apps/static/css/project.scss
@@ -3656,3 +3656,9 @@ ol#search-results dl {
 // }
 /*# sourceMappingURL=project.css.map */
 
+
+// NOTE: Migrated from templates/page.html
+#v-readux.uk-container {
+  padding: 0;
+  max-width: none;
+}

--- a/apps/templates/base.html
+++ b/apps/templates/base.html
@@ -62,7 +62,7 @@
     <meta property="og:image" content="https://{{ request.META.HTTP_HOST }}/apps/static/images/readux_logo.jpg" />
     <meta property="og:description" content="Read, Annotate, Publish" />
     <meta name="twitter:description" content="Read, Annotate, Publish" />
-    <!--<meta property="og:url" content="https://readux.ecds.emory.edu" />-->
+    <meta property="og:url" content="https://{{ request.META.HTTP_HOST }}" />
     {% endif %}
     <meta name="twitter:image:alt" content="Readux Logo - Emory Center for Digital scholarship - Read, Annotate, Publish" />
     <meta property="og:site_name" content="{{ current_site.site_name }}" />
@@ -81,35 +81,45 @@
     {% block css %}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.17.0/css/uikit.min.css" />
     <link href="{% static 'css/selectize.css' %}" rel="stylesheet">
-    <!-- <link type="text/css" href="{% sass_src 'css/project.scss' %}" rel="stylesheet"> -->
-    <link type="text/css" href="{% sass_src 'css/readux2/main.scss' %}" rel="stylesheet">
+    <link type="text/css" href="{% sass_src 'css/project.scss' %}" rel="stylesheet">
     <link type="text/css" href="{% sass_src 'css/readux2/login.scss' %}" rel="stylesheet">
-    <!-- <link type="text/css" href="css/project.scss" rel="stylesheet"> -->
-
-    <style>
-      {{ css }}
-    </style>
     {% endblock %}
     {% block extra_css %}{% endblock extra_css %}
 
   </head>
 
   <body>
+    {# NOTE: Jump to main content required for accessibility #}
+    <a class="sr-only" href="#main">Jump to main content</a>
 
-  {% block content %}
-  
-  {% endblock content %}
+    {# Primary container; host for Vue application #}
+    <div class="uk-container" id="v-readux">
+      {# TODO: Remove  #}
+      {% comment %} {% include "_home/_nav.html" %} {% endcomment %}
 
-  <div id="v-readux"></div>
-  
-  <!-- <a class="sr-only" href="#main">Jump to main content</a> -->
-  {% if request.get_host == "readux2.ecdsdev.org" %}
-  {% elif request.get_host == "readux.ecdsdev.org" %}
-  <div style="background-color:sandybrown;width:100%;height:1.5em;color:darkslategrey;text-align:center;font-size:1.4em;">
-  DEVELOPMENT SITE: Go to <a href="https://readux2.ecdsdev.org" style="color:red;text-decoration:underline;">Beta</a> for beta-testing or go to fully functioning
-  <a href="https://readux.ecds.emory.edu/" style="color:darkblue;text-decoration:underline;">Readux</a>.
-  </div>
-  {% endif %}
+      {# Content container #}
+      <main id='main'>
+        {# Django errors and alerts #}
+        {% if messages %}
+            {% for message in messages %}
+              <div class="uk-alert-{{ message.tags }}" uk-alert>
+                <a class="uk-alert-close" uk-close></a>
+                <p>{{ message }}</p>
+              </div>
+            {% endfor %}
+        {% endif %}
+
+        {% block modal %}
+        {% endblock modal %}
+
+        {% block content %}
+        {% endblock content %}
+
+        {# IIIF viewer #}
+        {% block viewer %}{% endblock viewer %}
+      </main>
+
+    </div>
   
     <!-- Matomo Image Tracker-->
     <img referrerpolicy="no-referrer-when-downgrade" src="https://matomo.ecdsdev.org/matomo.php?idsite=3&amp;rec=1" hidden alt="" />

--- a/apps/templates/base.html
+++ b/apps/templates/base.html
@@ -94,7 +94,10 @@
 
     {# Primary container; host for Vue application #}
     <div class="uk-container" id="v-readux">
-      {# TODO: Remove  #}
+      {% comment %}
+        TODO: Remove existing nav and replace with the following partial.
+        It seems it may be added elsewhere; vue? needs investigation.
+      {% endcomment %}
       {% comment %} {% include "_home/_nav.html" %} {% endcomment %}
 
       {# Content container #}

--- a/apps/templates/cms/home_page.html
+++ b/apps/templates/cms/home_page.html
@@ -4,6 +4,11 @@
 {% load wagtailcore_tags %}
 {% load has_user_annotations %}
 {% load user_annotation_count %}
+{% load sass_tags %}
+
+{% block extra_css %}
+<link type="text/css" href="{% sass_src 'css/readux2/main.scss' %}" rel="stylesheet">
+{% endblock %}
 
 {% block content %}
 

--- a/apps/templates/page.html
+++ b/apps/templates/page.html
@@ -8,10 +8,6 @@
   #rx-nav {
     display: none;
   }
-  .uk-container {
-    padding: 0;
-    max-width: none;
-  }
 </style>
 {% endblock extra_css %}
 


### PR DESCRIPTION
Fixing errors with the viewer:
- Restored the `viewer` block to the `base.html` template
    - It may appear "empty" in the base template but this is a part of Django templating: in an extendable template like `base.html`, you create an empty block, and then in pages that have `{% extends 'base.html' %}` you put things inside of that block
    - For the IIIF viewer pages, you can see what goes inside of it at `apps/templates/page.html`
        - Also, at the bottom of that page you can see where the error was: `ECDSAnnotator` is being initialized with `id: 'rdx-viewer'`, but the element with that ID was not being rendered by Django due to the `viewer` block being removed from `base.html`
- Restored the original CSS to prevent the viewer from being invisible
    - Moved the new CSS to `{% extra_css %}` block in `home_page.html`. This isn’t strictly necessary, but it’s helpful to isolate CSS that's only used on one page. If there’s new CSS that’s going to be shared across the whole site then it can go back in `base.html`
    - Added a quick rule in the old CSS, that was previously only used on volume pages, which prevents the entire page width from being constrained to 1200px. This should allow the old CSS to coexist with the new CSS on the home page now.


Other notes:

- There’s no need to leave backups of files in the codebase because the codebase is version controlled on GitHub. So you can just refer back to other branches or commits on GitHub to see previous versions.
- Same goes for commented out code—I recommend not committing commented-out code because it makes things much less readable and confusing about what needs to stay and what doesn't. You can always refer back to previous commits if something breaks or you need to reference something that was removed.
